### PR TITLE
setup.sh: graceful fallback when pip can't reach PyPI (proxy/firewall)

### DIFF
--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -134,6 +134,30 @@ fi
 echo
 
 # ─── Step 4: Install Python dependencies ─────────────────────────────────────
+# Maps PyPI package names to their Python import module names (where they differ)
+_pkg_to_module() {
+    case "$(echo "$1" | tr '[:upper:]' '[:lower:]')" in
+        pyyaml)       echo yaml ;;
+        pillow)       echo PIL ;;
+        scikit-learn) echo sklearn ;;
+        opencv-python) echo cv2 ;;
+        beautifulsoup4) echo bs4 ;;
+        *)            echo "${1,,}" | tr '-' '_' ;;
+    esac
+}
+
+# Returns 0 if every real package in a requirements file is already importable
+_reqs_importable() {
+    local req="$1"
+    while IFS= read -r line; do
+        local pkg mod
+        pkg="$(echo "$line" | sed 's/[><=!;[:space:]\[].*//')"
+        mod="$(_pkg_to_module "$pkg")"
+        "$PY3" -c "import ${mod}" 2>/dev/null || return 1
+    done < <(grep -vE '^\s*#|^\s*$' "$req")
+    return 0
+}
+
 echo
 info "Installing Python dependencies for all tools ..."
 PY3="$(command -v python3 2>/dev/null || true)"
@@ -142,17 +166,25 @@ if [[ -z "$PY3" ]]; then
 else
     for req in "${REPO_ROOT}/tools"/*/requirements.txt; do
         tool_name="$(basename "$(dirname "$req")")"
-        # Only lines that are not blank and not pure comments
         pkgs="$(grep -vE '^\s*#|^\s*$' "$req" 2>/dev/null || true)"
         if [[ -z "$pkgs" ]]; then
             skip "${tool_name}: no external Python dependencies."
             continue
         fi
-        info "${tool_name}: installing from $(basename "$(dirname "$req")")/requirements.txt ..."
-        if "$PY3" -m pip install --user -q --disable-pip-version-check -r "$req"; then
+        info "${tool_name}: checking dependencies ..."
+        if "$PY3" -m pip install --user -q --disable-pip-version-check -r "$req" 2>/dev/null; then
             ok "${tool_name}: dependencies satisfied."
         else
-            warn "${tool_name}: pip install failed — run manually: pip install -r ${req}"
+            # pip failed (network/proxy timeout) — check if packages are already importable
+            if _reqs_importable "$req"; then
+                skip "${tool_name}: packages already importable — pip skipped (no network needed)."
+            else
+                warn "${tool_name}: pip install failed AND packages are not importable."
+                warn "  If behind a proxy, retry with:"
+                warn "    pip install --user -r ${req} \\"
+                warn "      --proxy \"\${HTTPS_PROXY:-\${https_proxy}}\" \\"
+                warn "      --trusted-host pypi.org --trusted-host files.pythonhosted.org"
+            fi
         fi
     done
 fi

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -78,7 +78,7 @@ info "Repo root  : ${REPO_ROOT}"
 info "Alias file : ${ALIASES_FILE}"
 echo
 
-# ─── Step 2: Ensure aliases file exists ──────────────────────────────────────
+# ─── Step 1: Ensure aliases file exists ──────────────────────────────────────
 if [[ ! -f "${ALIASES_FILE}" ]]; then
     touch "${ALIASES_FILE}"
     info "Created ${ALIASES_FILE}"
@@ -113,7 +113,7 @@ if [[ ${#CONFLICTS[@]} -gt 0 ]]; then
     echo
 fi
 
-# ─── Step 3: Check and fix exec permissions on bin/ tools ────────────────────
+# ─── Step 3: Fix exec permissions on bin/ tools ──────────────────────────────
 echo
 info "Checking exec permissions on bin/ tools ..."
 FIXED=0


### PR DESCRIPTION
Fixes the ConnectTimeoutError users behind a corporate proxy see in Step 4.\n\nNew behaviour when pip install fails:\n- If all required packages are already importable → [SKIP] silently (tools will work)\n- If packages are truly missing → [WARN] with actionable retry instructions including --proxy and --trusted-host flags\n\nAlso adds _pkg_to_module() mapping (pyyaml→yaml, pillow→PIL, scikit-learn→sklearn, …) for reliable import-check regardless of PyPI name.