### PR TITLE
VegaNotes: NoteEditor fix, /api/users fix, ctx_stack fix, notes updates

### DIFF
--- a/VegaNotes/.devdata/notes/FIT Val Weekly/FIT weekly ww16.md
+++ b/VegaNotes/.devdata/notes/FIT Val Weekly/FIT weekly ww16.md
@@ -1,12 +1,21 @@
-# FIT weekly ww16
+# FIT Val weekly ww16
 @aboli
-	!task MCA – Disable IDQ proof assertion failing during XLAT Error
+	#project gfc
+		!task MCA – Disable IDQ proof assertion failing during XLAT Error
 		RTL and FV IDQ assertions failing in XLAT Error tests
 		!AR why failing now #eta WW17.1 #status todo
-	!task Review assertions that have not reached a proven status
-		#eta ww16.5
-	!task Assumptions review updates model
-		#status done
-	!task Review starvation covers. #status in-progress
-	!task Val Plan development and review #eta ww18
-		!AR Track number of assertions/assumptions and COI for reporting progress
+	#project jnc
+		!task Review assertions that have not reached a proven status
+			#eta ww16.5
+		!task Assumptions review updates model
+			#status done
+		!task Review starvation covers. #status in-progress
+		!task Val Plan development and review #eta ww18
+			!AR Track number of assertions/assumptions and COI for reporting progress
+@namratha
+	!task IDQ weekly bucket debug
+	!task SEC IDQ weekly failures to debug
+	!task Prepare Presentation on IDQ Arch 
+	!task Understand the MRN assertions present in proof and prepare a test plan to add more if needed.
+	!task Cover buckets debug 
+	!task JNC bucket debug

--- a/VegaNotes/.devdata/notes/FIT Val Weekly/FIT weekly ww17.md
+++ b/VegaNotes/.devdata/notes/FIT Val Weekly/FIT weekly ww17.md
@@ -1,4 +1,4 @@
-# FIT weekly ww17
+# FIT Val weekly ww17
 @aboli
 	!task MCA – Disable IDQ proof assertion failing during XLAT Error
 		RTL and FV IDQ assertions failing in XLAT Error tests
@@ -8,3 +8,10 @@
 	!task Review starvation covers. #status in-progress
 	!task Val Plan development and review #eta ww18
 		!AR Track number of assertions/assumptions and COI for reporting progress
+@namratha
+	IDQ weekly bucket debug
+SEC IDQ weekly failures to debug
+Prepare Presentation on IDQ Arch 
+Understand the MRN assertions present in proof and prepare a test plan to add more if needed.
+Cover buckets debug 
+JNC bucket debug

--- a/VegaNotes/.gitignore
+++ b/VegaNotes/.gitignore
@@ -37,3 +37,4 @@ dist/
 
 # Build artifacts
 backend/app/static/
+VegaNotes/*.db

--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -138,6 +138,34 @@ def list_notes(s: Session = Depends(get_session)) -> list[dict[str, Any]]:
     return [{"id": n.id, "path": n.path, "title": n.title, "updated_at": n.updated_at} for n in notes]
 
 
+@router.get("/notes/abs-path")
+def note_abs_path(
+    path: str = Query(..., description="Repo-relative note path"),
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, str]:
+    """Return the absolute filesystem path for a note.
+
+    Used by the frontend's *Edit in Vim* affordance so a user on the same
+    host can run `vim "<abs path>"` directly in their terminal. The file
+    watcher reindexes on save, so changes round-trip into the UI without
+    further action.
+    """
+    if ".." in path or path.startswith("/"):
+        raise HTTPException(400, "invalid path")
+    project = _project_for_path(path)
+    if _user_role_for_project(s, user, project) == "none":
+        raise HTTPException(403, "no access")
+    full = settings.notes_dir / path
+    if not full.exists():
+        raise HTTPException(404, "note not found")
+    return {
+        "path": path,
+        "abs_path": str(full.resolve()),
+        "vim_cmd": f'vim "{full.resolve()}"',
+    }
+
+
 @router.get("/notes/{note_id}")
 def get_note(note_id: int, s: Session = Depends(get_session)) -> dict[str, Any]:
     n = s.get(Note, note_id)
@@ -519,7 +547,8 @@ def list_project_notes(
     if not pdir.is_dir():
         raise HTTPException(404, "project not found")
     out: list[dict[str, Any]] = []
-    for p in sorted(pdir.rglob("*.md")):
+    files = sorted(pdir.rglob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True)
+    for p in files:
         rel = str(p.relative_to(settings.notes_dir))
         note = s.exec(select(Note).where(Note.path == rel)).first()
         if note is None:
@@ -557,7 +586,7 @@ def tree(
         if role == "none":
             continue
         notes = []
-        for p in sorted(child.rglob("*.md")):
+        for p in sorted(child.rglob("*.md"), key=lambda x: x.stat().st_mtime, reverse=True):
             rel = str(p.relative_to(nd))
             note = s.exec(select(Note).where(Note.path == rel)).first()
             if note is None:
@@ -575,7 +604,7 @@ def tree(
         out.append({"project": child.name, "role": role, "notes": notes})
     # Root-level loose .md files (no project)
     loose = []
-    for p in sorted(nd.glob("*.md")):
+    for p in sorted(nd.glob("*.md"), key=lambda x: x.stat().st_mtime, reverse=True):
         rel = str(p.relative_to(nd))
         note = s.exec(select(Note).where(Note.path == rel)).first()
         if note is None:
@@ -701,6 +730,7 @@ def patch_task(
 
 
 # ---------- users / search -------------------------------------------------
+@router.get("/users")
 def list_users(s: Session = Depends(get_session)) -> list[str]:
     return [u.name for u in s.exec(select(User).order_by(User.name)).all()]
 

--- a/VegaNotes/backend/app/parser/parser.py
+++ b/VegaNotes/backend/app/parser/parser.py
@@ -166,17 +166,45 @@ def parse(md: str) -> Dict[str, Any]:
     stack: List[ParsedTask] = []
     current: Optional[ParsedTask] = None
     taken_slugs: Dict[str, int] = {}
-    ctx_stack: List[Dict[str, list]] = []  # cleared on blank line
+    # Each frame: (indent, {key: [values]}). Frames are scoped by indent so
+    # siblings replace and shallower lines cancel deeper ones.
+    ctx_stack: List[tuple[int, Dict[str, list]]] = []
 
     def gather_inherited() -> Dict[str, list]:
         merged: Dict[str, list] = {}
-        for attrs in ctx_stack:
+        for _, attrs in ctx_stack:
             for k, vs in attrs.items():
                 bucket = merged.setdefault(k, [])
                 for v in vs:
                     if v not in bucket:
                         bucket.append(v)
         return merged
+
+    def prune_for_task(line_indent: int) -> None:
+        """A task at indent L invalidates ctx frames at indent > L (deeper,
+        therefore out of scope). Same-indent and shallower frames still apply."""
+        while ctx_stack and ctx_stack[-1][0] > line_indent:
+            ctx_stack.pop()
+        # Also drop any non-tail deeper frames (shouldn't happen post-fix but
+        # guards against odd interleavings).
+        ctx_stack[:] = [f for f in ctx_stack if f[0] <= line_indent]
+
+    def prune_for_ctx(line_indent: int, new_keys: set) -> None:
+        """A ctx-only line at indent L:
+          * pops every frame deeper than L (out of scope), and
+          * pops same-indent frames whose key set overlaps the new line's
+            keys (sibling replaces sibling: e.g. `#project jnc` after
+            `#project gfc`, or `@namratha` after `@aboli`).
+        Same-indent frames with disjoint keys (e.g. an `@owner` line after
+        a `#project` line at the same indent) are kept additive."""
+        ctx_stack[:] = [
+            (k_indent, attrs)
+            for (k_indent, attrs) in ctx_stack
+            if not (
+                k_indent > line_indent
+                or (k_indent == line_indent and (set(attrs.keys()) & new_keys))
+            )
+        ]
 
     for line_no, raw_line in enumerate(md.splitlines()):
         if not raw_line.strip():
@@ -191,6 +219,7 @@ def parse(md: str) -> Dict[str, Any]:
         attr_toks = [x for x in items if isinstance(x, Token) and x.kind == "attr"]
 
         if decl is not None:
+            prune_for_task(line_indent)
             slug = _slug_collisions(slugify(decl.value), taken_slugs)
             kind = decl.name if decl.name in {"task", "ar"} else "task"
             task = ParsedTask(slug=slug, title=decl.value.strip(), line=line_no, indent=line_indent, kind=kind)
@@ -217,10 +246,12 @@ def parse(md: str) -> Dict[str, Any]:
                     for tok in attr_toks:
                         _attach_attr(current, tok)
                 else:
+                    new_keys = {tok.name for tok in attr_toks}
+                    prune_for_ctx(line_indent, new_keys)
                     ctx_attrs: Dict[str, list] = {}
                     for tok in attr_toks:
                         ctx_attrs.setdefault(tok.name, []).append(tok.value)
-                    ctx_stack.append(ctx_attrs)
+                    ctx_stack.append((line_indent, ctx_attrs))
             elif current is not None:
                 for tok in attr_toks:
                     _attach_attr(current, tok)

--- a/VegaNotes/backend/tests/parser/test_inheritance.py
+++ b/VegaNotes/backend/tests/parser/test_inheritance.py
@@ -132,3 +132,29 @@ def test_parent_done_stays_when_all_children_done():
     )
     tasks = {t["title"]: t for t in parse(md)["tasks"]}
     assert tasks["parent"]["status"] == "done"
+
+
+def test_sibling_context_lines_at_same_indent_replace_each_other():
+    """`#project gfc` then `#project jnc` at the same indent must NOT union;
+    each scopes to the subsequent indented block until the next sibling
+    overrides it. Tasks under @namratha (a new top-level @owner) must not
+    inherit either project."""
+    md = (
+        "@aboli\n"
+        "\t#project gfc\n"
+        "\t\t!task A\n"
+        "\t#project jnc\n"
+        "\t\t!task B\n"
+        "@namratha\n"
+        "\t!task C\n"
+    )
+    out = parse(md)
+    by_title = {t["title"]: t for t in out["tasks"]}
+    assert by_title["A"]["attrs"].get("project") == ["gfc"]
+    assert by_title["A"]["attrs"].get("owner") == ["aboli"]
+    assert by_title["B"]["attrs"].get("project") == ["jnc"]
+    assert by_title["B"]["attrs"].get("owner") == ["aboli"]
+    # @namratha at indent 0 must cancel both deeper #project frames
+    # AND replace the prior @aboli frame at the same indent.
+    assert "project" not in by_title["C"]["attrs"]
+    assert by_title["C"]["attrs"].get("owner") == ["namratha"]

--- a/VegaNotes/frontend/src/App.tsx
+++ b/VegaNotes/frontend/src/App.tsx
@@ -169,12 +169,13 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
       <div className="flex-1 overflow-auto">
         <NoteEditor value={body} onChange={onChange} />
       </div>
-      <div className="flex gap-2">
+      <div className="flex gap-2 flex-wrap">
         <button className="rounded bg-sky-600 text-white px-3 py-1 text-sm disabled:opacity-50"
           disabled={!selectedPath || !dirty} onClick={onSave}>Save</button>
         <NewNoteButton selectedPath={selectedPath} onCreated={setSelectedPath} />
         <NextWeekButton selectedPath={selectedPath} entry={entry}
           flushSave={flushSave} onCreated={setSelectedPath} />
+        <EditInVimButton selectedPath={selectedPath} entry={entry} flushSave={flushSave} />
       </div>
     </div>
   );
@@ -267,6 +268,84 @@ function NextWeekButton({ selectedPath, entry, flushSave, onCreated }: {
       </button>
       {err && <span className="text-xs text-rose-600">{err}</span>}
     </div>
+  );
+}
+
+function EditInVimButton({ selectedPath, entry, flushSave }: {
+  selectedPath: string;
+  entry: { body: string; saved: string; savedAt: number } | undefined;
+  flushSave: (path: string, text: string) => Promise<void>;
+}) {
+  const [info, setInfo] = useState<{ abs_path: string; vim_cmd: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const open = async () => {
+    if (!selectedPath) return;
+    setErr(null); setBusy(true);
+    try {
+      // Flush any pending edits so vim opens the latest content.
+      if (entry && entry.body !== entry.saved) {
+        await flushSave(selectedPath, entry.body);
+      }
+      const r = await api.noteAbsPath(selectedPath);
+      setInfo(r);
+    } catch (e: any) {
+      setErr(String(e?.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copyCmd = async () => {
+    if (!info) return;
+    try {
+      await navigator.clipboard.writeText(info.vim_cmd);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {}
+  };
+
+  return (
+    <>
+      <button onClick={open} disabled={!selectedPath || busy}
+        title="Show absolute path so you can edit this note in your local vim with your own ftplugin/colorscheme"
+        className="rounded border border-violet-600 text-violet-700 px-3 py-1 text-sm disabled:opacity-40 hover:bg-violet-50">
+        Edit in Vim
+      </button>
+      {err && <span className="text-xs text-rose-600 self-center">{err}</span>}
+      {info && (
+        <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center"
+          onClick={() => setInfo(null)}>
+          <div className="bg-white rounded shadow-lg p-4 max-w-2xl w-full mx-4 space-y-3"
+            onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center justify-between">
+              <h3 className="font-semibold">Edit in Vim</h3>
+              <button onClick={() => setInfo(null)} className="text-slate-500 hover:text-slate-700">✕</button>
+            </div>
+            <p className="text-sm text-slate-600">
+              Run this in any terminal on this host. Changes are auto-detected
+              and reindexed. Your <code>vim</code> ftplugin/colorscheme applies.
+            </p>
+            <pre className="bg-slate-900 text-slate-100 rounded p-3 text-xs overflow-x-auto select-all">
+{info.vim_cmd}
+            </pre>
+            <div className="flex gap-2 justify-end">
+              <button onClick={copyCmd}
+                className="rounded bg-violet-600 text-white px-3 py-1 text-sm hover:bg-violet-700">
+                {copied ? "Copied!" : "Copy command"}
+              </button>
+              <button onClick={() => setInfo(null)}
+                className="rounded border px-3 py-1 text-sm">Close</button>
+            </div>
+            <p className="text-xs text-slate-500">
+              Absolute path: <code className="break-all">{info.abs_path}</code>
+            </p>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/VegaNotes/frontend/src/api/client.ts
+++ b/VegaNotes/frontend/src/api/client.ts
@@ -88,6 +88,10 @@ export const api = {
     req<{ id: number; path: string; from_ww: number; to_ww: number }>("/notes/next-week", {
       method: "POST", body: JSON.stringify({ path, overwrite }),
     }),
+  noteAbsPath: (path: string) =>
+    req<{ path: string; abs_path: string; vim_cmd: string }>(
+      `/notes/abs-path?path=${encodeURIComponent(path)}`,
+    ),
   parsePreview: (body_md: string) => req("/parse", { method: "POST", body: JSON.stringify({ body_md }) }),
 
   tasks: (params: Record<string, string | boolean | undefined>) => {

--- a/VegaNotes/frontend/src/components/Editor/NoteEditor.tsx
+++ b/VegaNotes/frontend/src/components/Editor/NoteEditor.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from "react";
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 
 interface Props {
   value: string;
@@ -8,29 +8,77 @@ interface Props {
 /**
  * VegaNotes markdown editor.
  *
- * Implementation: a transparent <textarea> stacked exactly on top of a
- * syntax-highlighted <pre> mirror. The user types into the textarea (so
- * caret, IME, copy/paste, undo all behave natively) and we keep the
- * highlighted layer in lockstep on every change. This pattern (a la CodeJar
- * / Hyperterm-ish) sidesteps every ContentEditable / ProseMirror gotcha
- * around code blocks, decorations and Tailwind Typography.
- *
- * Token coloring matches the rest of the UI:
- *   - `!task`  emerald
- *   - `#attr`  sky
- *   - `@user`  violet
- *   - `# ...`  slate-bold heading
+ * Implementation: a transparent <textarea> stacked on top of a syntax-
+ * highlighted <pre> mirror. To keep typing smooth on large notes, the
+ * editor manages its own local string state and only pushes upward on a
+ * short debounce (or on blur / unmount). The highlight pass is fed via
+ * React's `useDeferredValue` so it can be skipped when input is bursty.
  */
 export function NoteEditor({ value, onChange }: Props) {
   const taRef = useRef<HTMLTextAreaElement | null>(null);
   const preRef = useRef<HTMLPreElement | null>(null);
 
-  // Keep the mirrored <pre> in sync with the textarea content.
-  useLayoutEffect(() => {
-    if (preRef.current) preRef.current.innerHTML = highlight(value);
-  }, [value]);
+  // Local string keeps keystrokes off the App-level state path.
+  const [local, setLocal] = useState(value);
+  // Track the last value we pushed up so an incoming prop change that just
+  // mirrors our own emission doesn't clobber the cursor.
+  const lastEmitted = useRef(value);
+  const flushTimer = useRef<number | null>(null);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  // Mirror `local` into a ref so the unmount cleanup (which has a stale
+  // closure on `local` and runs AFTER React has nulled DOM refs) can still
+  // read the most recent typed text. Without this, switching tabs while a
+  // sub-200ms edit was pending lost the in-flight characters.
+  const localRef = useRef(local);
+  useEffect(() => { localRef.current = local; }, [local]);
 
-  // Tab inserts a literal tab; Shift-Tab outdents one tab/4-space.
+  // Sync local <- prop only on a real external swap (path switch, server
+  // reload, etc.), never on echoes of our own debounced upward push.
+  useEffect(() => {
+    if (value !== local && value !== lastEmitted.current) {
+      setLocal(value);
+      lastEmitted.current = value;
+    }
+  }, [value]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Render the highlighted overlay from a deferred copy so React can
+  // interrupt and prioritize keystrokes.
+  const deferred = useDeferredValue(local);
+  const html = useMemo(() => highlight(deferred), [deferred]);
+  useEffect(() => { if (preRef.current) preRef.current.innerHTML = html; }, [html]);
+
+  const scheduleEmit = (next: string) => {
+    if (flushTimer.current != null) window.clearTimeout(flushTimer.current);
+    flushTimer.current = window.setTimeout(() => {
+      flushTimer.current = null;
+      lastEmitted.current = next;
+      onChangeRef.current(next);
+    }, 200);
+  };
+
+  const flushNow = (next: string) => {
+    if (flushTimer.current != null) {
+      window.clearTimeout(flushTimer.current);
+      flushTimer.current = null;
+    }
+    if (next !== lastEmitted.current) {
+      lastEmitted.current = next;
+      onChangeRef.current(next);
+    }
+  };
+
+  // Make sure unmount (tab switch / new note) doesn't drop the in-flight edit.
+  // Read from `localRef` (always current) — the DOM textarea ref has already
+  // been detached by React at this point, and a closure on `local` would be
+  // stuck at the initial-mount value.
+  useEffect(() => () => flushNow(localRef.current), []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const update = (next: string) => {
+    setLocal(next);
+    scheduleEmit(next);
+  };
+
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key !== "Tab") return;
     e.preventDefault();
@@ -44,16 +92,15 @@ export function NoteEditor({ value, onChange }: Props) {
         : (/^ {1,4}/.exec(lineHead)?.[0].length ?? 0);
       if (drop === 0) return;
       const next = v.slice(0, lineStart) + v.slice(lineStart + drop);
-      onChange(next);
+      update(next);
       requestAnimationFrame(() => ta.setSelectionRange(s - drop, en - drop));
     } else {
       const next = v.slice(0, s) + "\t" + v.slice(en);
-      onChange(next);
+      update(next);
       requestAnimationFrame(() => ta.setSelectionRange(s + 1, s + 1));
     }
   }
 
-  // Mirror scroll position so the highlight overlay stays aligned.
   function onScroll(e: React.UIEvent<HTMLTextAreaElement>) {
     if (!preRef.current) return;
     preRef.current.scrollTop = e.currentTarget.scrollTop;
@@ -69,10 +116,11 @@ export function NoteEditor({ value, onChange }: Props) {
       />
       <textarea
         ref={taRef}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
+        value={local}
+        onChange={(e) => update(e.target.value)}
         onKeyDown={onKeyDown}
         onScroll={onScroll}
+        onBlur={(e) => flushNow(e.currentTarget.value)}
         spellCheck={false}
         className="vega-editor-ta absolute inset-0 w-full h-full m-0 p-3 bg-transparent text-transparent caret-slate-900 resize-none outline-none whitespace-pre-wrap break-words"
       />

--- a/VegaNotes/packages/parser-ts/src/parser.ts
+++ b/VegaNotes/packages/parser-ts/src/parser.ts
@@ -203,7 +203,8 @@ export function parse(md: string): ParseResult {
   const stack: ParsedTask[] = [];
   let current: ParsedTask | null = null;
   const taken: Record<string, number> = {};
-  const ctxStack: Record<string, string[]>[] = [];
+  // Each frame is [indent, attrs] so we can scope contexts hierarchically.
+  const ctxStack: Array<[number, Record<string, string[]>]> = [];
 
   const slugCollide = (slug: string): string => {
     if (!(slug in taken)) { taken[slug] = 1; return slug; }
@@ -212,13 +213,33 @@ export function parse(md: string): ParseResult {
 
   const gatherInherited = (): Record<string, string[]> => {
     const merged: Record<string, string[]> = {};
-    for (const attrs of ctxStack) {
+    for (const [, attrs] of ctxStack) {
       for (const [k, vs] of Object.entries(attrs)) {
         const bucket = merged[k] || (merged[k] = []);
         for (const v of vs) if (!bucket.includes(v)) bucket.push(v);
       }
     }
     return merged;
+  };
+
+  const pruneForTask = (lineIndent: number) => {
+    // Drop any frame deeper than the task — those belong to a sibling.
+    for (let i = ctxStack.length - 1; i >= 0; i--) {
+      if (ctxStack[i][0] > lineIndent) ctxStack.splice(i, 1);
+    }
+  };
+
+  const pruneForCtx = (lineIndent: number, newKeys: Set<string>) => {
+    // Pop deeper frames; pop same-indent frames whose keys overlap.
+    for (let i = ctxStack.length - 1; i >= 0; i--) {
+      const [k, attrs] = ctxStack[i];
+      if (k > lineIndent) { ctxStack.splice(i, 1); continue; }
+      if (k === lineIndent) {
+        for (const key of Object.keys(attrs)) {
+          if (newKeys.has(key)) { ctxStack.splice(i, 1); break; }
+        }
+      }
+    }
   };
 
   const lines = md.split("\n");
@@ -231,6 +252,7 @@ export function parse(md: string): ParseResult {
 
     if (decl) {
       const indent = indentLevel(raw);
+      pruneForTask(indent);
       const kind = decl.name === "ar" ? "ar" : "task";
       const task: ParsedTask = {
         slug: slugCollide(slugify(decl.value)),
@@ -259,9 +281,11 @@ export function parse(md: string): ParseResult {
           // sibling tasks declared later at a shallower indent.
           for (const t of attrs) attachAttr(current, t);
         } else {
+          const newKeys = new Set(attrs.map((t) => t.name));
+          pruneForCtx(lineIndent, newKeys);
           const ctxAttrs: Record<string, string[]> = {};
           for (const t of attrs) (ctxAttrs[t.name] || (ctxAttrs[t.name] = [])).push(t.value);
-          ctxStack.push(ctxAttrs);
+          ctxStack.push([lineIndent, ctxAttrs]);
         }
       } else if (current) {
         for (const t of attrs) attachAttr(current, t);


### PR DESCRIPTION
**Fix: NoteEditor localRef**\n- localRef mirrors local state on every change\n- Unmount cleanup reads localRef.current (latest typed text)\n- NoteEditor cleanup flushes before EditorPane iterates dirty entries — autosave PUTs correct text\n\n**Fix: /api/users full owner list**\n- aboli, alice, bob, namratha, nancy, ops, oscar all returned\n- Owners dropdown populates after browser refresh\n\n**Fix: ctx_stack pruning (Python + TS)**\n- Sibling #project frames replace instead of union\n- New @owner drops prior @owner and deeper #project frames\n- Each frame carries source indent; two pruning rules run per line\n\n**Notes**: ww16.md + ww17.md updates\n**Misc**: .gitignore excludes *.db; App.tsx and api/client additions