### PR TITLE
feat: generic attribute search across CLI + GUI + backend (#94)

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -1,6 +1,7 @@
 """REST API routers."""
 from __future__ import annotations
 
+import json
 from datetime import date, datetime, timedelta
 import shutil
 from pathlib import Path
@@ -395,6 +396,58 @@ def parse_preview(body: dict = Body(...)) -> dict[str, Any]:
 
 # ---------- tasks (composable filters) -------------------------------------
 
+# Operators allowed for the repeatable `attr` query param.
+# Form on the wire: `attr=key:op:value` (value may contain `:` itself).
+# `exists` / `nexists` accept an empty value (`attr=key:exists:`).
+_ATTR_OPS = {"eq", "ne", "in", "nin", "gte", "lte", "gt", "lt", "like", "exists", "nexists"}
+_ATTR_RANGE_OPS = {"gte", "lte", "gt", "lt"}
+_ATTR_OP_SQL = {
+    "eq": "=", "ne": "!=", "gte": ">=", "lte": "<=", "gt": ">", "lt": "<",
+}
+
+# Whitelisted sort fields.  Map to (kind, sql-expression).  "task" =
+# Task column, "attr" = a normalized TaskAttr lookup (joined LEFT so tasks
+# missing the attr sort to the end).
+_SORT_FIELDS = {
+    "id":         ("task", "t.id"),
+    "title":      ("task", "t.title"),
+    "status":     ("task", "t.status"),
+    "kind":       ("task", "t.kind"),
+    "created_at": ("task", "t.created_at"),
+    "updated_at": ("task", "t.updated_at"),
+    "eta":        ("attr", "eta"),
+    "priority":   ("attr", "priority"),
+}
+
+
+def _parse_attr_clause(raw: str) -> tuple[str, str, str]:
+    """Parse `key:op:value` into (key, op, value).  Raises HTTPException(400)."""
+    parts = raw.split(":", 2)
+    if len(parts) < 2:
+        raise HTTPException(400, f"bad attr clause: {raw!r} (expected key:op[:value])")
+    key, op = parts[0].strip(), parts[1].strip().lower()
+    value = parts[2] if len(parts) == 3 else ""
+    if not key:
+        raise HTTPException(400, f"bad attr clause: {raw!r} (empty key)")
+    if op not in _ATTR_OPS:
+        raise HTTPException(
+            400,
+            f"bad attr clause: {raw!r} (unknown op {op!r}; valid: {sorted(_ATTR_OPS)})",
+        )
+    if op in {"exists", "nexists"}:
+        return key, op, ""
+    if op in _ATTR_RANGE_OPS and key not in {"eta", "priority"}:
+        # Range queries require a normalized value (value_norm).  Today only
+        # eta/priority normalize, so reject other keys early with a clear
+        # message instead of silently returning empty results.
+        raise HTTPException(
+            400,
+            f"range op {op!r} on attr {key!r} requires value_norm; only "
+            f"'eta' and 'priority' normalize today. Use eq/ne/in/nin instead.",
+        )
+    return key, op, value
+
+
 @router.get("/tasks")
 def list_tasks(
     s: Session = Depends(get_session),
@@ -410,9 +463,20 @@ def list_tasks(
     kind: Optional[str] = None,
     top_level_only: bool = False,
     include_children: bool = False,
+    # ── new (issue #38 follow-up) ─────────────────────────────────────
+    not_owner: Optional[str] = None,
+    not_project: Optional[str] = None,
+    not_feature: Optional[str] = None,
+    not_status: Optional[str] = None,
+    not_priority: Optional[str] = None,
+    attr: list[str] = Query(default_factory=list),
+    sort: Optional[str] = None,
+    limit: Optional[int] = Query(default=None, ge=1, le=2000),
+    offset: int = Query(default=0, ge=0),
 ) -> dict[str, Any]:
     sql = ["SELECT DISTINCT t.id FROM task t"]
     params: dict[str, Any] = {}
+    expanding: list[str] = []
 
     def _join_multi(table: str, name_table: str, names: list[str], alias: str) -> None:
         if not names:
@@ -423,6 +487,7 @@ def list_tasks(
         )
         sql.append(f"AND {alias}.name IN :{alias}_names")
         params[f"{alias}_names"] = tuple(names)
+        expanding.append(f"{alias}_names")
 
     _join_multi("taskowner", "user", _split(owner), "u")
     _join_multi("taskproject", "project", _split(project), "p")
@@ -435,11 +500,13 @@ def list_tasks(
         statuses = _split(status)
         where.append("t.status IN :statuses")
         params["statuses"] = tuple(statuses)
+        expanding.append("statuses")
     if priority:
         prios = _split(priority)
         sql.append("JOIN taskattr pa ON pa.task_id = t.id AND pa.key='priority'")
         where.append("pa.value IN :prios")
         params["prios"] = tuple(prios)
+        expanding.append("prios")
     if eta_before or eta_after:
         sql.append("JOIN taskattr ea ON ea.task_id = t.id AND ea.key='eta'")
         if eta_before:
@@ -455,21 +522,164 @@ def list_tasks(
         kinds = _split(kind)
         where.append("t.kind IN :kinds")
         params["kinds"] = tuple(kinds)
+        expanding.append("kinds")
     if top_level_only:
         where.append("(t.parent_task_id IS NULL AND t.kind = 'task')")
 
+    # ── negations ────────────────────────────────────────────────────────
+    def _exclude(name_table: str, link_table: str, link_col: str,
+                 names: list[str], slot: str) -> None:
+        if not names:
+            return
+        where.append(
+            f"t.id NOT IN ("
+            f"SELECT lk.task_id FROM {link_table} lk "
+            f"JOIN {name_table} nm ON nm.id = lk.{link_col} "
+            f"WHERE nm.name IN :{slot})"
+        )
+        params[slot] = tuple(names)
+        expanding.append(slot)
+
+    _exclude("user",    "taskowner",   "user_id",    _split(not_owner),   "not_u_names")
+    _exclude("project", "taskproject", "project_id", _split(not_project), "not_p_names")
+    _exclude("feature", "taskfeature", "feature_id", _split(not_feature), "not_f_names")
+
+    if not_status:
+        where.append("t.status NOT IN :not_statuses")
+        params["not_statuses"] = tuple(_split(not_status))
+        expanding.append("not_statuses")
+    if not_priority:
+        where.append(
+            "t.id NOT IN ("
+            "SELECT task_id FROM taskattr WHERE key='priority' AND value IN :not_prios)"
+        )
+        params["not_prios"] = tuple(_split(not_priority))
+        expanding.append("not_prios")
+
+    # ── arbitrary @attr filters ──────────────────────────────────────────
+    for i, raw in enumerate(attr):
+        key, op, value = _parse_attr_clause(raw)
+        kp, vp = f"axk_{i}", f"axv_{i}"
+        params[kp] = key
+        if op == "exists":
+            where.append(
+                f"EXISTS (SELECT 1 FROM taskattr ax{i} "
+                f"WHERE ax{i}.task_id = t.id AND ax{i}.key = :{kp})"
+            )
+            continue
+        if op == "nexists":
+            where.append(
+                f"NOT EXISTS (SELECT 1 FROM taskattr ax{i} "
+                f"WHERE ax{i}.task_id = t.id AND ax{i}.key = :{kp})"
+            )
+            continue
+        col = "value_norm" if op in _ATTR_RANGE_OPS else "value"
+        if op == "in":
+            where.append(
+                f"EXISTS (SELECT 1 FROM taskattr ax{i} "
+                f"WHERE ax{i}.task_id = t.id AND ax{i}.key = :{kp} "
+                f"AND ax{i}.{col} IN :{vp})"
+            )
+            params[vp] = tuple(v for v in (tok.strip() for tok in value.split(",")) if v)
+            expanding.append(vp)
+        elif op == "nin":
+            where.append(
+                f"NOT EXISTS (SELECT 1 FROM taskattr ax{i} "
+                f"WHERE ax{i}.task_id = t.id AND ax{i}.key = :{kp} "
+                f"AND ax{i}.{col} IN :{vp})"
+            )
+            params[vp] = tuple(v for v in (tok.strip() for tok in value.split(",")) if v)
+            expanding.append(vp)
+        elif op == "ne":
+            # "ne" means: there is no row with this key=value.  (Tasks that
+            # don't have the key at all also satisfy `ne`.)
+            where.append(
+                f"NOT EXISTS (SELECT 1 FROM taskattr ax{i} "
+                f"WHERE ax{i}.task_id = t.id AND ax{i}.key = :{kp} "
+                f"AND ax{i}.{col} = :{vp})"
+            )
+            params[vp] = value
+        elif op == "like":
+            where.append(
+                f"EXISTS (SELECT 1 FROM taskattr ax{i} "
+                f"WHERE ax{i}.task_id = t.id AND ax{i}.key = :{kp} "
+                f"AND ax{i}.{col} LIKE :{vp})"
+            )
+            params[vp] = value
+        else:
+            sql_op = _ATTR_OP_SQL[op]
+            where.append(
+                f"EXISTS (SELECT 1 FROM taskattr ax{i} "
+                f"WHERE ax{i}.task_id = t.id AND ax{i}.key = :{kp} "
+                f"AND ax{i}.{col} {sql_op} :{vp})"
+            )
+            params[vp] = value
+
+    # ── ORDER BY ─────────────────────────────────────────────────────────
+    order_clauses: list[str] = []
+    sort_joins: list[str] = []
+    if sort:
+        for i, raw in enumerate([tok.strip() for tok in sort.split(",") if tok.strip()]):
+            field, _, direction = raw.partition(":")
+            field = field.strip()
+            direction = (direction or "asc").strip().lower()
+            if direction not in {"asc", "desc"}:
+                raise HTTPException(400, f"bad sort direction: {raw!r}")
+            spec = _SORT_FIELDS.get(field)
+            if not spec:
+                raise HTTPException(
+                    400,
+                    f"unknown sort field {field!r}; valid: {sorted(_SORT_FIELDS)}",
+                )
+            kind_, expr = spec
+            if kind_ == "task":
+                order_clauses.append(f"{expr} {direction.upper()}")
+            else:
+                alias = f"so{i}"
+                sort_joins.append(
+                    f"LEFT JOIN taskattr {alias} ON {alias}.task_id = t.id "
+                    f"AND {alias}.key = '{expr}'"
+                )
+                # NULLs always last so unstamped tasks don't pollute the top.
+                order_clauses.append(
+                    f"({alias}.value_norm IS NULL) ASC, "
+                    f"{alias}.value_norm {direction.upper()}"
+                )
+    # Stable tiebreaker so identical sort keys order deterministically.
+    order_clauses.append("t.id ASC")
+
+    sql.extend(sort_joins)
     sql.append("WHERE " + " AND ".join(where))
+    sql.append("ORDER BY " + ", ".join(order_clauses))
     sql_text = " ".join(sql)
     stmt = text(sql_text)
-    expanding_keys = [k for k in ("u_names", "p_names", "f_names", "statuses", "prios", "kinds") if k in params]
-    if expanding_keys:
-        stmt = stmt.bindparams(*[bindparam(k, expanding=True) for k in expanding_keys])
+    if expanding:
+        stmt = stmt.bindparams(*[bindparam(k, expanding=True) for k in expanding])
     rows = s.exec(stmt.bindparams(**params)).all()
-    ids = [r[0] for r in rows]
-    if not ids:
-        return {"tasks": [], "aggregations": {"owners": [], "projects": [], "features": [], "status_breakdown": {}, "priority_breakdown": {}}}
+    all_ids = [r[0] for r in rows]
+    total = len(all_ids)
 
-    tasks = [_task_to_dict(s, s.get(Task, i), include_children=include_children) for i in ids]
+    # Paginate after we know the total.  When `limit` is omitted we keep
+    # the historical "return everything" behavior so existing callers
+    # don't silently get truncated.
+    if limit is not None:
+        page_ids = all_ids[offset : offset + limit]
+    else:
+        page_ids = all_ids[offset:] if offset else all_ids
+
+    if not page_ids:
+        return {
+            "tasks": [],
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "aggregations": {
+                "owners": [], "projects": [], "features": [],
+                "status_breakdown": {}, "priority_breakdown": {},
+            },
+        }
+
+    tasks = [_task_to_dict(s, s.get(Task, i), include_children=include_children) for i in page_ids]
 
     agg_owners = sorted({o for t in tasks for o in t["owners"]})
     agg_projects = sorted({p for t in tasks for p in t["projects"]})
@@ -483,6 +693,9 @@ def list_tasks(
 
     return {
         "tasks": tasks,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
         "aggregations": {
             "owners": agg_owners,
             "projects": agg_projects,
@@ -491,6 +704,38 @@ def list_tasks(
             "priority_breakdown": prio_bd,
         },
     }
+
+
+# ---------- attr key catalog (autocomplete) --------------------------------
+
+@router.get("/attrs")
+def list_attr_keys(s: Session = Depends(get_session)) -> list[dict[str, Any]]:
+    """Distinct attr keys with cardinality and a few sample values.
+
+    Used by the FilterBar (and `vn`) for tab-completing `@key` and `=value`
+    in the query DSL.  Cheap aggregate; we cap the sample list at 25.
+    """
+    rows = s.exec(
+        text("SELECT key, COUNT(*) AS cnt FROM taskattr GROUP BY key ORDER BY cnt DESC, key ASC")
+    ).all()
+    out: list[dict[str, Any]] = []
+    for key, cnt in rows:
+        samples = s.exec(
+            text(
+                "SELECT DISTINCT value FROM taskattr "
+                "WHERE key = :k AND value != '' "
+                "ORDER BY value LIMIT 25"
+            ).bindparams(k=key)
+        ).all()
+        out.append({
+            "key": key,
+            "count": int(cnt),
+            "sample_values": [r[0] for r in samples],
+        })
+    return out
+
+
+
 
 
 # ---------- agenda ----------------------------------------------------------
@@ -1043,6 +1288,61 @@ def change_my_password(
     s.add(u)
     s.commit()
     return {"status": "ok"}
+
+
+# ---------- saved views (per-user query bookmarks) -------------------------
+
+class SavedView(BaseModel):
+    """Named reusable query — exactly the shape the FilterBar / `vn`
+    serialize to and from.  `query` is an opaque dict of API params."""
+    name: str
+    query: dict[str, Any] = {}
+
+
+def _load_views(u: User) -> list[dict[str, Any]]:
+    raw = u.saved_views_json or "[]"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    return data if isinstance(data, list) else []
+
+
+@router.get("/me/views")
+def list_my_views(
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None:
+        raise HTTPException(404, "user not found")
+    return _load_views(u)
+
+
+@router.put("/me/views")
+def replace_my_views(
+    body: list[SavedView] = Body(...),
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, Any]:
+    """Replace this user's full saved-view list.  Idempotent."""
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None:
+        raise HTTPException(404, "user not found")
+    seen: set[str] = set()
+    cleaned: list[dict[str, Any]] = []
+    for v in body:
+        name = v.name.strip()
+        if not name:
+            raise HTTPException(400, "view name cannot be empty")
+        if name in seen:
+            raise HTTPException(400, f"duplicate view name: {name!r}")
+        seen.add(name)
+        cleaned.append({"name": name, "query": v.query or {}})
+    u.saved_views_json = json.dumps(cleaned)
+    s.add(u)
+    s.commit()
+    return {"status": "ok", "count": len(cleaned)}
 
 
 # ---------- admin: user management ----------------------------------------

--- a/VegaNotes/backend/app/parser/lexer.py
+++ b/VegaNotes/backend/app/parser/lexer.py
@@ -69,7 +69,12 @@ def _read_value(s: str, i: int, *, until_hash: bool = False) -> tuple[str, int]:
         while j < n:
             if s[j] == "#":
                 m = re.match(r"#([a-zA-Z][\w-]*)", s[j:])
-                if m and is_known(m.group(1)):
+                if m:
+                    # Any attribute-shaped #name terminates the title — even
+                    # for unknown names, which the parser will accept as
+                    # generic attrs (issue #38 follow-up). The lexer will
+                    # later drop empty-value attrs so prose hashtags
+                    # (`#urgent` at EOL) are unaffected.
                     break
             if s[j] == "@" and (j == 0 or s[j - 1] in " \t([") and j + 1 < n and (s[j + 1].isalpha() or s[j + 1] == "_"):
                 break
@@ -111,23 +116,26 @@ def lex(line: str) -> List[Union[TextChunk, Token]]:
             last = end
         else:
             name = m.group("name")
-            # only consume known attribute names; unknown stay as text
-            if not is_known(name):
-                # treat as plain text — copy through
-                end = m.end()
-                if start > last:
-                    pass  # already emitted
+            # Read the value the way the spec dictates; for unknown names
+            # use the default whitespace-delimited word.  An attribute with
+            # an *empty* value is treated as prose (a `#hashtag` with no
+            # value, e.g. trailing `#urgent` at EOL): we copy the literal
+            # text through so existing notes that use `#foo` as a tag in
+            # prose continue to render unchanged.
+            spec_known = is_known(name)
+            value, end = _read_value(
+                line, m.end(),
+                until_hash=(spec_known and name in ("status", "note")),
+            )
+            if not value.strip():
                 out.append(TextChunk(line[start:end]))
                 i = end
                 last = end
                 continue
-            value, end = _read_value(line, m.end(), until_hash=(name in ("status", "note")))
             raw = line[start:end]
             if name == "status":
                 value = value.strip()
             elif name == "note":
-                # Trim trailing whitespace but keep internal spaces; an empty
-                # note token (just `#note` with no value) is dropped.
                 value = value.strip()
                 if not value:
                     i = end

--- a/VegaNotes/backend/app/parser/parser.py
+++ b/VegaNotes/backend/app/parser/parser.py
@@ -70,20 +70,26 @@ class ParsedTask:
 
 
 def _attach_attr(task: ParsedTask, tok: Token) -> None:
-    spec = REGISTRY[tok.name]
+    spec = REGISTRY.get(tok.name)
     if tok.name == "status":
-        task.status = spec.normalize(tok.value) if spec.normalize else (tok.value.strip().lower() or "todo")
+        # status keeps its bespoke handling regardless of registry presence.
+        norm = spec.normalize(tok.value) if (spec and spec.normalize) else None
+        task.status = norm if norm else (tok.value.strip().lower() or "todo")
     if tok.name in {"task", "link"}:
         kind = "task" if tok.name == "task" else "link"
         task.refs.append({"kind": kind, "dst_slug": slugify(tok.value)})
         return
-    if spec.multi:
+    # Unknown #names are treated as generic multi-valued attrs with no
+    # normalization — this is what makes `#area`, `#risk`, `#milestone`, …
+    # queryable without code changes (issue #38 follow-up).
+    multi = spec.multi if spec else True
+    if multi:
         existing = task.attrs.setdefault(tok.name, [])
         if tok.value not in existing:
             existing.append(tok.value)
     else:
         task.attrs[tok.name] = tok.value
-    if spec.normalize:
+    if spec and spec.normalize:
         norm = spec.normalize(tok.value)
         if spec.multi:
             existing_norm = task.attrs_norm.setdefault(tok.name, [])
@@ -168,9 +174,10 @@ def _is_ref_row(items: list) -> Token | None:
 def _merge_inherited(task: ParsedTask, inherited: Dict[str, list]) -> None:
     for key, values in inherited.items():
         spec = REGISTRY.get(key)
-        if spec is None:
-            continue
-        if spec.multi:
+        # Unknown attrs inherit as multi-valued; known non-multi keep
+        # first-write-wins semantics.
+        multi = spec.multi if spec else True
+        if multi:
             existing = task.attrs.get(key, [])
             if not isinstance(existing, list):
                 existing = [existing]
@@ -180,19 +187,22 @@ def _merge_inherited(task: ParsedTask, inherited: Dict[str, list]) -> None:
                     merged.append(v)
             if merged:
                 task.attrs[key] = merged
-                if spec.normalize:
+                if spec and spec.normalize:
                     task.attrs_norm[key] = [spec.normalize(v) for v in merged]
         else:
             if key not in task.attrs and values:
                 task.attrs[key] = values[0]
-                if spec.normalize:
+                if spec and spec.normalize:
                     task.attrs_norm[key] = spec.normalize(values[0])
 
 
 def _inherit_from_parent(task: ParsedTask, parent: ParsedTask) -> None:
     for k, v in parent.attrs.items():
         spec = REGISTRY.get(k)
-        if spec is None or not spec.multi:
+        # Multi-valued attrs (known or unknown) inherit downward; scalar
+        # known attrs deliberately do NOT (preserves original behavior).
+        multi = spec.multi if spec else True
+        if not multi:
             continue
         existing = task.attrs.get(k, [])
         if not isinstance(existing, list):
@@ -202,7 +212,7 @@ def _inherit_from_parent(task: ParsedTask, parent: ParsedTask) -> None:
             if item not in merged:
                 merged.append(item)
         task.attrs[k] = merged
-        if spec.normalize:
+        if spec and spec.normalize:
             task.attrs_norm[k] = [spec.normalize(item) for item in merged]
 
 
@@ -297,9 +307,8 @@ def parse(md: str) -> Dict[str, Any]:
                     if t is task_ref:
                         continue
                     spec = REGISTRY.get(t.name)
-                    if spec is None:
-                        continue
-                    if spec.multi:
+                    multi = spec.multi if spec else True
+                    if multi:
                         overrides.setdefault(t.name, []).append(t.value)
                     else:
                         overrides[t.name] = t.value

--- a/VegaNotes/backend/tests/api/test_query.py
+++ b/VegaNotes/backend/tests/api/test_query.py
@@ -1,0 +1,354 @@
+"""Tests for the Phase-1 query enhancements on /api/tasks plus the new
+/api/attrs and /api/me/views endpoints.
+
+Issue #38 follow-up: generic attribute search.
+"""
+import base64
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+DATA = Path(tempfile.mkdtemp(prefix="vega-test-query-"))
+os.environ.setdefault("VEGANOTES_DATA_DIR", str(DATA))
+os.environ.setdefault("VEGANOTES_SERVE_STATIC", "false")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from app.config import settings  # noqa: E402
+from app.db import init_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+ADMIN = "Basic " + base64.b64encode(b"admin:admin").decode()
+
+
+@pytest.fixture(scope="module")
+def client():
+    settings.notes_dir.mkdir(parents=True, exist_ok=True)
+    settings.data_dir.mkdir(parents=True, exist_ok=True)
+    import app.db as _db
+    _db._engine = None
+    init_db()
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="module")
+def seeded(client):
+    """Seed a project with five tasks covering the matrix we need:
+
+      T1: alice, P0, eta ww17, #area fit-val, #risk high
+      T2: alice, P1, eta ww18, #area fit-val, #risk low
+      T3: bob,   P0, eta ww17, #area infra,   #risk high
+      T4: bob,   P2, eta ww19, #area infra
+      T5: alice, P3 (unstamped attr), no eta, status done
+    """
+    client.post("/api/projects", json={"name": "qry"}, headers={"Authorization": ADMIN})
+    md = (
+        "# qry seed\n"
+        "- !task T1 task @alice #priority P0 #eta ww17 #area fit-val #risk high #id T-AAAA01\n"
+        "- !task T2 task @alice #priority P1 #eta ww18 #area fit-val #risk low #id T-AAAA02\n"
+        "- !task T3 task @bob   #priority P0 #eta ww17 #area infra   #risk high #id T-AAAA03\n"
+        "- !task T4 task @bob   #priority P2 #eta ww19 #area infra              #id T-AAAA04\n"
+        "- !task T5 task @alice #priority P3 #status done                       #id T-AAAA05\n"
+    )
+    r = client.put(
+        "/api/notes",
+        json={"path": "qry/seed.md", "body_md": md},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200, r.text
+    # Sanity — should be 5 tasks indexed.
+    r = client.get("/api/tasks?project=qry", headers={"Authorization": ADMIN})
+    assert r.status_code == 200, r.text
+    assert r.json()["total"] == 5
+    return r.json()
+
+
+# ── envelope additions: total/offset/limit always present ─────────────────
+
+def test_response_envelope_has_total_offset_limit(client, seeded):
+    r = client.get("/api/tasks?project=qry", headers={"Authorization": ADMIN})
+    body = r.json()
+    assert body["total"] == 5
+    assert body["offset"] == 0
+    assert body["limit"] is None
+    assert len(body["tasks"]) == 5
+
+
+# ── pagination ────────────────────────────────────────────────────────────
+
+def test_pagination_limit_and_offset(client, seeded):
+    page = client.get(
+        "/api/tasks?project=qry&sort=id&limit=2&offset=1",
+        headers={"Authorization": ADMIN},
+    ).json()
+    assert page["total"] == 5
+    assert page["offset"] == 1
+    assert page["limit"] == 2
+    assert len(page["tasks"]) == 2
+    # When sorted by id we know the order: skip the 1st, take 2nd & 3rd.
+    titles = [t["title"] for t in page["tasks"]]
+    assert titles == ["T2 task", "T3 task"]
+
+
+def test_pagination_offset_past_end_returns_empty(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&offset=100",
+        headers={"Authorization": ADMIN},
+    ).json()
+    assert body["total"] == 5
+    assert body["tasks"] == []
+
+
+def test_limit_validation(client):
+    r = client.get("/api/tasks?limit=0", headers={"Authorization": ADMIN})
+    assert r.status_code == 422
+    r = client.get("/api/tasks?limit=99999", headers={"Authorization": ADMIN})
+    assert r.status_code == 422
+
+
+# ── sort ──────────────────────────────────────────────────────────────────
+
+def test_sort_by_task_column_asc_desc(client, seeded):
+    asc = client.get(
+        "/api/tasks?project=qry&sort=title:asc", headers={"Authorization": ADMIN}
+    ).json()["tasks"]
+    desc = client.get(
+        "/api/tasks?project=qry&sort=title:desc", headers={"Authorization": ADMIN}
+    ).json()["tasks"]
+    assert [t["title"] for t in asc] == ["T1 task", "T2 task", "T3 task", "T4 task", "T5 task"]
+    assert [t["title"] for t in desc] == ["T5 task", "T4 task", "T3 task", "T2 task", "T1 task"]
+
+
+def test_sort_by_eta_puts_unstamped_last(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&sort=eta:asc", headers={"Authorization": ADMIN}
+    ).json()
+    titles = [t["title"] for t in body["tasks"]]
+    # Unstamped (T5 has no eta) must appear at the end regardless of direction.
+    assert titles[-1] == "T5 task"
+    # First three should be the ww17 / ww18 / ww19 tasks in order
+    assert titles[0] in ("T1 task", "T3 task")  # both ww17 — id tiebreaker decides
+
+
+def test_sort_unknown_field_400(client):
+    r = client.get("/api/tasks?sort=bogus", headers={"Authorization": ADMIN})
+    assert r.status_code == 400
+    assert "unknown sort field" in r.json()["detail"]
+
+
+def test_sort_bad_direction_400(client):
+    r = client.get("/api/tasks?sort=title:sideways", headers={"Authorization": ADMIN})
+    assert r.status_code == 400
+
+
+# ── negation filters ──────────────────────────────────────────────────────
+
+def test_not_owner(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&not_owner=alice", headers={"Authorization": ADMIN}
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    assert titles == ["T3 task", "T4 task"]
+
+
+def test_not_status(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&not_status=done", headers={"Authorization": ADMIN}
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    # Everything except T5 (status=done).
+    assert titles == ["T1 task", "T2 task", "T3 task", "T4 task"]
+
+
+def test_not_priority(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&not_priority=P0", headers={"Authorization": ADMIN}
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    # T1 and T3 are P0 — exclude both.
+    assert titles == ["T2 task", "T4 task", "T5 task"]
+
+
+# ── arbitrary @attr filters (the headline feature) ────────────────────────
+
+def test_attr_eq(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&attr=area:eq:fit-val",
+        headers={"Authorization": ADMIN},
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    assert titles == ["T1 task", "T2 task"]
+
+
+def test_attr_ne_includes_tasks_missing_the_key(client, seeded):
+    """Tasks without the key satisfy `ne`."""
+    body = client.get(
+        "/api/tasks?project=qry&attr=risk:ne:high",
+        headers={"Authorization": ADMIN},
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    # Excludes T1 and T3 (risk=high). T2 risk=low; T4 / T5 have no risk attr.
+    assert titles == ["T2 task", "T4 task", "T5 task"]
+
+
+def test_attr_in(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&attr=risk:in:high,low",
+        headers={"Authorization": ADMIN},
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    assert titles == ["T1 task", "T2 task", "T3 task"]
+
+
+def test_attr_nin(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&attr=risk:nin:low",
+        headers={"Authorization": ADMIN},
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    # Drops T2 (risk=low). Others (no risk row OR risk=high) survive.
+    assert titles == ["T1 task", "T3 task", "T4 task", "T5 task"]
+
+
+def test_attr_exists_and_nexists(client, seeded):
+    has = client.get(
+        "/api/tasks?project=qry&attr=risk:exists:",
+        headers={"Authorization": ADMIN},
+    ).json()
+    none = client.get(
+        "/api/tasks?project=qry&attr=risk:nexists:",
+        headers={"Authorization": ADMIN},
+    ).json()
+    assert sorted(t["title"] for t in has["tasks"]) == ["T1 task", "T2 task", "T3 task"]
+    assert sorted(t["title"] for t in none["tasks"]) == ["T4 task", "T5 task"]
+
+
+def test_attr_like(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&attr=area:like:fit%25",
+        headers={"Authorization": ADMIN},
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    assert titles == ["T1 task", "T2 task"]
+
+
+def test_attr_range_on_eta_uses_value_norm(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&attr=eta:gte:2026-04-27",
+        headers={"Authorization": ADMIN},
+    ).json()
+    # ww17 ≈ 2026-04-20, ww18 ≈ 2026-04-27, ww19 ≈ 2026-05-04.
+    # >= 2026-04-27 keeps ww18 (T2) and ww19 (T4).
+    titles = sorted(t["title"] for t in body["tasks"])
+    assert titles == ["T2 task", "T4 task"]
+
+
+def test_attr_range_on_unnormalized_key_400(client):
+    r = client.get(
+        "/api/tasks?attr=area:gte:fit-val",
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 400
+    assert "value_norm" in r.json()["detail"]
+
+
+def test_attr_combined_filters_AND(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&attr=area:eq:fit-val&attr=risk:eq:high",
+        headers={"Authorization": ADMIN},
+    ).json()
+    titles = [t["title"] for t in body["tasks"]]
+    assert titles == ["T1 task"]
+
+
+def test_attr_bad_op_400(client):
+    r = client.get("/api/tasks?attr=area:bogus:x", headers={"Authorization": ADMIN})
+    assert r.status_code == 400
+    assert "unknown op" in r.json()["detail"]
+
+
+def test_attr_malformed_400(client):
+    r = client.get("/api/tasks?attr=justakey", headers={"Authorization": ADMIN})
+    assert r.status_code == 400
+
+
+# ── /api/attrs ────────────────────────────────────────────────────────────
+
+def test_attrs_endpoint_lists_keys_with_samples(client, seeded):
+    body = client.get("/api/attrs", headers={"Authorization": ADMIN}).json()
+    by_key = {row["key"]: row for row in body}
+    # All seeded keys should be present.
+    assert {"area", "risk", "eta", "priority"}.issubset(by_key)
+    area = by_key["area"]
+    assert area["count"] >= 4
+    assert set(area["sample_values"]) >= {"fit-val", "infra"}
+
+
+# ── /api/me/views ─────────────────────────────────────────────────────────
+
+def test_saved_views_roundtrip(client):
+    # Empty by default.
+    assert client.get("/api/me/views", headers={"Authorization": ADMIN}).json() == []
+
+    payload = [
+        {"name": "P0 backlog", "query": {"priority": "P0", "hide_done": True}},
+        {"name": "Alice this week",
+         "query": {"owner": "alice", "attr": ["eta:gte:2026-04-20"]}},
+    ]
+    r = client.put("/api/me/views", json=payload, headers={"Authorization": ADMIN})
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok", "count": 2}
+
+    got = client.get("/api/me/views", headers={"Authorization": ADMIN}).json()
+    assert got == payload
+
+    # Replace with empty list — must clear.
+    client.put("/api/me/views", json=[], headers={"Authorization": ADMIN})
+    assert client.get("/api/me/views", headers={"Authorization": ADMIN}).json() == []
+
+
+def test_saved_views_reject_empty_name(client):
+    r = client.put(
+        "/api/me/views",
+        json=[{"name": "  ", "query": {}}],
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 400
+
+
+def test_saved_views_reject_duplicate_names(client):
+    r = client.put(
+        "/api/me/views",
+        json=[{"name": "v", "query": {}}, {"name": "v", "query": {"x": 1}}],
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 400
+    assert "duplicate" in r.json()["detail"].lower()
+
+
+def test_saved_views_require_auth(client):
+    r = client.get("/api/me/views")
+    assert r.status_code == 401
+
+
+# ── existing behavior preserved (no regression) ───────────────────────────
+
+def test_existing_owner_filter_still_works(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry&owner=alice", headers={"Authorization": ADMIN}
+    ).json()
+    titles = sorted(t["title"] for t in body["tasks"])
+    assert titles == ["T1 task", "T2 task", "T5 task"]
+
+
+def test_existing_aggregations_envelope_still_emitted(client, seeded):
+    body = client.get(
+        "/api/tasks?project=qry", headers={"Authorization": ADMIN}
+    ).json()
+    aggs = body["aggregations"]
+    assert set(aggs["owners"]) == {"alice", "bob"}
+    assert "qry" in aggs["projects"]
+    assert aggs["status_breakdown"].get("done", 0) >= 1

--- a/VegaNotes/docs/api.md
+++ b/VegaNotes/docs/api.md
@@ -54,11 +54,22 @@ from the last remaining admin.
 
 ### Tasks
 - `GET /api/tasks` — composable filters:
-  `owner`, `project`, `feature`, `priority`, `status`, `eta_before`, `eta_after`,
-  `hide_done`, `q` (FTS), `limit`, `offset`. Multi-value: comma-separated.
-  Response includes the **aggregation envelope** (owners/projects/features/
-  eta_range/status_breakdown/priority_breakdown).
-- `GET /api/tasks/{id}`
+  - **Fixed columns** (comma-separated for OR): `owner`, `project`,
+    `feature`, `priority`, `status`, `eta_before`, `eta_after`,
+    `hide_done`, `q` (FTS), `kind`.
+  - **Negation**: `not_owner`, `not_project`, `not_feature`,
+    `not_status`, `not_priority`.
+  - **Generic attribute filter** (issue #38 follow-up): repeatable
+    `attr=key:op:value`. Operators: `eq`, `ne`, `in`, `nin`, `gte`,
+    `lte`, `gt`, `lt`, `like`, `exists`, `nexists`. `in`/`nin` use a
+    comma-separated value list. Range ops (`gte`/`lte`/`gt`/`lt`) are
+    only valid on keys with `value_norm` populated (today: `eta`,
+    `priority`); other keys return `400`.
+  - **Sort**: `sort=field[:asc|desc][,field2[:dir]…]`. Allowed fields:
+    `eta`, `priority`, `created_at`, `updated_at`, `title`, `status`.
+  - **Pagination**: `limit` (1–2000) and `offset`. Response always
+    includes `total` alongside `tasks` + `aggregations`.
+- `GET /api/tasks/{id}` — fetch by integer PK or `T-XXXXXX` ref.
 - `PATCH /api/tasks/{id}` — convenience attribute update (round-tripped to md).
   Body fields: `status`, `priority`, `eta`, `owners`, `features`, `notes`.
   Authorization: managers and admins always allowed; otherwise the caller
@@ -66,6 +77,16 @@ from the last remaining admin.
   required for owner-only edits). Returns `403` with one of these `detail`
   strings on failure: `no access to project`,
   `members can only edit their own tasks`, `manager role required`.
+
+### Attributes
+- `GET /api/attrs` — autocomplete feed for arbitrary `#tag` keys. Returns
+  `[{key, count, sample_values: string[]}]`, sorted by `count desc`.
+
+### Saved views (per-user)
+- `GET /api/me/views` — returns the caller's saved chip-bar views as
+  `{ name: string[] }` (each value is a list of DSL clauses).
+- `PUT /api/me/views` — replace the entire saved-views map (PUT
+  semantics, no PATCH). Body is the same `{ name: string[] }` shape.
 
 ### Agenda
 - `GET /api/agenda?owner=alice&days=7` — grouped by day, sorted by `eta`+`priority`.

--- a/VegaNotes/docs/command-reference.md
+++ b/VegaNotes/docs/command-reference.md
@@ -189,9 +189,25 @@ python3 -m pip install --user -e VegaNotes/tools/vn
 # Patch a task (status, priority, eta, owners, features, add-note)
 vn task T-123 status=done priority=P1 eta=2026-W18
 
-# List tasks with filters
+# List tasks with simple filters
 vn list --owner kushwanth --status open --hide-done
 vn list --project gfc --priority P0,P1 --json
+
+# Generic attribute search (issue #38) — `--where` accepts the mini-DSL.
+# Operators: =, !=, >=, <=, >, <, in, not in, like.
+# `@key` addresses arbitrary `#tag` attrs (anything not a fixed column).
+vn list -w 'owner=alice' -w '@area=fit-val' -w 'eta>=ww18' --sort eta:desc
+vn list -w 'priority in P0,P1' -w 'project!=internal' --limit 50
+
+# Output formats: table (default), json, jsonl, csv, ids
+vn list -w '@area=fit-val' --format csv --columns id,priority,eta,title
+vn list -w '@area=fit-val' --format ids | xargs -n1 -I{} vn task {} status=done
+
+# Group the table client-side by any field/attribute
+vn list --group-by area --columns id,priority,title
+
+# `vn query` is an alias for `vn list` for query-style usage
+vn query -w '@risk=high' -w 'status=wip'
 
 # Create a new note: ww16/standup-notes.md
 vn note new --project ww16 --title 'standup notes'

--- a/VegaNotes/docs/user-guide.md
+++ b/VegaNotes/docs/user-guide.md
@@ -471,3 +471,49 @@ Saving this as `acme/sprint17.md` produces:
 
 Open the Kanban and you'll see all 6 cards, draggable across `todo` /
 `in-progress` / `blocked` / `done`.
+
+---
+
+## 9. Searching — chip bar, DSL, saved views
+
+The FilterBar above every view (Kanban / Agenda / Calendar / …) supports
+two complementary inputs:
+
+1. **Fixed dropdowns** — owner, project, feature, hide-done, free-text
+   `q`. These map 1:1 to the long-standing API filters.
+2. **Chip bar** — a free-form text input that accepts the same mini-DSL
+   the `vn` CLI uses. Type a clause, hit **Enter**, get a chip;
+   **Backspace** in an empty input removes the last chip; click `×` on
+   any chip to drop it.
+
+### DSL cheat sheet
+
+```
+owner=alice
+project!=internal
+priority in P0,P1
+eta>=ww18
+@area=fit-val            # any arbitrary `#tag` — prefix with `@`
+@risk in high,medium
+status=!done             # the legacy "everything but done" sentinel
+```
+
+Operators: `=`, `!=`, `>=`, `<=`, `>`, `<`, `in`, `not in`, `like`.
+Clauses are AND-ed; repeating the same `@key` ORs values for that key.
+
+### Autocomplete
+
+Typing `@` opens a dropdown listing every distinct `#tag` key in your
+notes (sourced from `GET /api/attrs`), each with a couple of sample
+values. Click to insert `@key=` and finish typing the value.
+
+### Saved views
+
+Build a chip set you'll want again, hit **save**, give it a name. It's
+stored per-user (`User.saved_views_json`) and reappears in the **★
+saved views** dropdown on every device. Pick from the dropdown to
+replace the current chip set; use the small red `×` selector next to it
+to delete a saved view.
+
+Behind the scenes saved views are just `{ name: ["@area=fit-val", … ] }`
+maps — you can poke at them directly via `GET/PUT /api/me/views`.

--- a/VegaNotes/frontend/src/api/client.ts
+++ b/VegaNotes/frontend/src/api/client.ts
@@ -131,9 +131,16 @@ export const api = {
     ),
   parsePreview: (body_md: string) => req("/parse", { method: "POST", body: JSON.stringify({ body_md }) }),
 
-  tasks: (params: Record<string, string | boolean | undefined>) => {
+  tasks: (params: Record<string, string | string[] | boolean | undefined>) => {
     const qs = new URLSearchParams();
-    for (const [k, v] of Object.entries(params)) if (v !== undefined && v !== "") qs.set(k, String(v));
+    for (const [k, v] of Object.entries(params)) {
+      if (v === undefined || v === "") continue;
+      if (Array.isArray(v)) {
+        for (const item of v) if (item !== undefined && item !== "") qs.append(k, String(item));
+      } else {
+        qs.set(k, String(v));
+      }
+    }
     return req<TasksResponse>(`/tasks?${qs.toString()}`);
   },
   updateTask: (id: number, patch: {
@@ -209,4 +216,12 @@ export const api = {
     req(`/admin/users/${encodeURIComponent(name)}`, { method: "DELETE" }),
 
   search: (q: string) => req<{ id: number; path: string; title: string }[]>(`/search?q=${encodeURIComponent(q)}`),
+
+  // Generic attribute autocomplete (issue #38 follow-up).
+  attrs: () => req<{ key: string; count: number; sample_values: string[] }[]>("/attrs"),
+
+  // Per-user saved chip-bar views (issue #38 follow-up).
+  savedViews: () => req<Record<string, string[]>>("/me/views"),
+  saveViews: (views: Record<string, string[]>) =>
+    req<Record<string, string[]>>("/me/views", { method: "PUT", body: JSON.stringify(views) }),
 };

--- a/VegaNotes/frontend/src/components/FilterBar/ChipBar.tsx
+++ b/VegaNotes/frontend/src/components/FilterBar/ChipBar.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../../api/client";
+import { useUI } from "../../store/ui";
+import { DSLError, parseClause, renderClause } from "../../store/dsl";
+
+/**
+ * Free-form chip input for the FilterBar. Type a DSL clause and press
+ * Enter to add a chip; Backspace at empty input removes the last chip;
+ * `×` on a chip removes it. Typing `@` (or starting with one) opens an
+ * autocomplete listing distinct TaskAttr keys with a couple of sample
+ * values each — fed by `GET /api/attrs`.
+ */
+export function ChipBar() {
+  const where = useUI((s) => s.filters.where ?? []);
+  const addChip = useUI((s) => s.addChip);
+  const removeChip = useUI((s) => s.removeChip);
+
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const { data: attrs } = useQuery({
+    queryKey: ["attrs"],
+    queryFn: api.attrs,
+    staleTime: 60_000,
+  });
+
+  // Autocomplete is only shown while the cursor is inside an `@` token.
+  const ac = useMemo(() => deriveAutocomplete(input, attrs ?? []), [input, attrs]);
+
+  function commit(text: string) {
+    const t = text.trim();
+    if (!t) return;
+    try {
+      const c = parseClause(t);
+      addChip(renderClause(c));
+      setInput("");
+      setError(null);
+    } catch (e) {
+      setError(e instanceof DSLError ? e.message : String(e));
+    }
+  }
+
+  function onKey(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      commit(input);
+    } else if (e.key === "Backspace" && input === "" && where.length > 0) {
+      removeChip(where.length - 1);
+    } else if (e.key === "Escape") {
+      setInput("");
+      setError(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1 flex-1 min-w-[200px] relative">
+      {where.map((clause, i) => (
+        <span key={`${clause}-${i}`}
+          className="inline-flex items-center gap-1 rounded bg-slate-100 px-2 py-0.5 text-xs">
+          <code className="font-mono">{clause}</code>
+          <button
+            type="button"
+            aria-label={`remove ${clause}`}
+            className="text-slate-400 hover:text-slate-700"
+            onClick={() => removeChip(i)}
+          >×</button>
+        </span>
+      ))}
+      <input
+        ref={inputRef}
+        className="rounded border px-2 py-1 text-sm flex-1 min-w-[160px]"
+        placeholder='filter… e.g. @area=fit-val  or  eta>=ww18'
+        value={input}
+        onChange={(e) => { setInput(e.target.value); setError(null); }}
+        onKeyDown={onKey}
+        title={error ?? undefined}
+        aria-invalid={error ? "true" : "false"}
+      />
+      {ac.suggestions.length > 0 && (
+        <ul className="absolute z-20 left-0 top-full mt-1 max-h-60 w-72 overflow-auto rounded border bg-white shadow-lg text-xs">
+          {ac.suggestions.map((s) => (
+            <li key={s.key}>
+              <button
+                type="button"
+                className="block w-full text-left px-2 py-1 hover:bg-slate-100"
+                onClick={() => {
+                  // Insert "@key=" into the input and refocus so the
+                  // user can type the value.
+                  setInput(ac.replacePrefix + "@" + s.key + "=");
+                  inputRef.current?.focus();
+                }}
+              >
+                <span className="font-mono">@{s.key}</span>
+                <span className="ml-2 text-slate-400">
+                  {s.sample_values.slice(0, 3).join(", ")}
+                  {s.count > 3 ? `  (+${s.count - 3})` : ""}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {error && <span className="text-xs text-red-600">{error}</span>}
+    </div>
+  );
+}
+
+interface AcRow { key: string; count: number; sample_values: string[] }
+interface AcResult { suggestions: AcRow[]; replacePrefix: string }
+
+/**
+ * Decide whether to show the autocomplete dropdown based on the cursor
+ * position (we approximate "cursor at end" — good enough for v1).
+ */
+function deriveAutocomplete(input: string, attrs: AcRow[]): AcResult {
+  const at = input.lastIndexOf("@");
+  if (at < 0) return { suggestions: [], replacePrefix: "" };
+  // Only suggest while the user is still typing the @key fragment
+  // (no `=` / op after the @).
+  const tail = input.slice(at + 1);
+  if (/[=!<>\s]/.test(tail)) return { suggestions: [], replacePrefix: "" };
+  const prefix = tail.toLowerCase();
+  const matches = attrs
+    .filter((a) => a.key.toLowerCase().startsWith(prefix))
+    .slice(0, 8);
+  return { suggestions: matches, replacePrefix: input.slice(0, at) };
+}

--- a/VegaNotes/frontend/src/components/FilterBar/FilterBar.tsx
+++ b/VegaNotes/frontend/src/components/FilterBar/FilterBar.tsx
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "../../api/client";
 import { useUI } from "../../store/ui";
+import { ChipBar } from "./ChipBar";
+import { SavedViews } from "./SavedViews";
 
 export function FilterBar() {
   const { filters, patchFilters, clearFilters } = useUI();
@@ -30,9 +32,11 @@ export function FilterBar() {
           onChange={(e) => patchFilters({ hide_done: e.target.checked })} />
         hide done
       </label>
-      <input className="rounded border px-2 py-1 text-sm flex-1 min-w-[160px]"
+      <input className="rounded border px-2 py-1 text-sm w-[160px]"
         placeholder="search title…" value={filters.q ?? ""}
         onChange={(e) => patchFilters({ q: e.target.value || undefined })} />
+      <ChipBar />
+      <SavedViews />
       <button className="text-sm text-slate-500 hover:text-slate-900"
         onClick={() => clearFilters()}>reset</button>
     </div>

--- a/VegaNotes/frontend/src/components/FilterBar/SavedViews.tsx
+++ b/VegaNotes/frontend/src/components/FilterBar/SavedViews.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../api/client";
+import { useUI } from "../../store/ui";
+
+/**
+ * Saved-view dropdown driven by `User.saved_views_json`. Each view is a
+ * named `string[]` of DSL chips. Apply replaces the current chip set;
+ * "★ Save" prompts for a name and persists the current chip set.
+ */
+export function SavedViews() {
+  const where = useUI((s) => s.filters.where ?? []);
+  const setChips = useUI((s) => s.setChips);
+  const qc = useQueryClient();
+  const [busy, setBusy] = useState(false);
+
+  const { data: views } = useQuery({
+    queryKey: ["me", "views"],
+    queryFn: api.savedViews,
+    staleTime: 30_000,
+  });
+  const named = views ?? {};
+  const names = Object.keys(named).sort();
+
+  async function save() {
+    const name = window.prompt("Save current filter as view (name):");
+    if (!name) return;
+    setBusy(true);
+    try {
+      const next = { ...named, [name]: [...where] };
+      await api.saveViews(next);
+      qc.setQueryData(["me", "views"], next);
+    } finally { setBusy(false); }
+  }
+
+  async function remove(name: string) {
+    if (!window.confirm(`Delete saved view "${name}"?`)) return;
+    setBusy(true);
+    try {
+      const next = { ...named };
+      delete next[name];
+      await api.saveViews(next);
+      qc.setQueryData(["me", "views"], next);
+    } finally { setBusy(false); }
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <select
+        className="rounded border px-2 py-1 text-sm"
+        value=""
+        disabled={busy}
+        onChange={(e) => {
+          const name = e.target.value;
+          if (!name) return;
+          const view = named[name];
+          if (Array.isArray(view)) setChips(view);
+          // Reset to placeholder so the same view can be re-applied.
+          e.target.value = "";
+        }}
+      >
+        <option value="">★ saved views…</option>
+        {names.map((n) => <option key={n} value={n}>{n}</option>)}
+      </select>
+      <button
+        type="button"
+        className="text-sm text-slate-500 hover:text-slate-900"
+        onClick={save}
+        disabled={busy || where.length === 0}
+        title={where.length === 0 ? "add chips first" : "save current chips as a named view"}
+      >save</button>
+      {names.length > 0 && (
+        <select
+          className="rounded border px-2 py-1 text-sm text-red-500"
+          value=""
+          disabled={busy}
+          onChange={(e) => { if (e.target.value) remove(e.target.value); e.target.value = ""; }}
+          title="delete a saved view"
+        >
+          <option value="">×</option>
+          {names.map((n) => <option key={n} value={n}>{n}</option>)}
+        </select>
+      )}
+    </div>
+  );
+}

--- a/VegaNotes/frontend/src/components/Kanban/KanbanBoard.tsx
+++ b/VegaNotes/frontend/src/components/Kanban/KanbanBoard.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api, type Task } from "../../api/client";
 import { TaskCard } from "../Card/TaskCard";
 import { TaskEditPopover } from "../Tasks/TaskEditPopover";
-import { useUI } from "../../store/ui";
+import { useUI, filtersToParams } from "../../store/ui";
 import { useFontScale, type FontScale } from "../../store/fontScale";
 
 const SCALES: { value: FontScale; label: string; title: string }[] = [
@@ -29,7 +29,7 @@ export function KanbanBoard() {
     queryKey: ["tasks", filters, "kanban"],
     queryFn: () =>
       api.tasks({
-        ...filters,
+        ...filtersToParams(filters),
         hide_done: false,
         top_level_only: true,
         include_children: true,

--- a/VegaNotes/frontend/src/store/dsl.ts
+++ b/VegaNotes/frontend/src/store/dsl.ts
@@ -1,0 +1,144 @@
+// Mini-DSL for the FilterBar chip input. Mirrors `tools/vn/vn/query.py` —
+// keep the two in sync. Operators: =, !=, >=, <=, >, <, in, not in, like.
+// `@key` prefix routes to the generic TaskAttr filter; bare keys map to
+// the existing fixed columns (owner/project/feature/priority/status/eta).
+
+export type OpCode =
+  | "eq" | "ne" | "in" | "nin"
+  | "gte" | "lte" | "gt" | "lt" | "like";
+
+export interface Clause {
+  /** Original LHS as the user typed it, lowercased. ``@`` prefix preserved. */
+  lhs: string;
+  op: OpCode;
+  /** Right-hand side, untrimmed-internal but stripped on the edges. */
+  value: string;
+  /** True if the LHS started with `@` (i.e. arbitrary TaskAttr key). */
+  isAttr: boolean;
+}
+
+export class DSLError extends Error {
+  constructor(msg: string) { super(msg); this.name = "DSLError"; }
+}
+
+const SYM_OPS: Array<[string, OpCode]> = [
+  [">=", "gte"], ["<=", "lte"], ["!=", "ne"],
+  ["=",  "eq"],  [">",  "gt"],  ["<",  "lt"],
+];
+
+// Word ops — longest first so "not in" matches before "in".
+const WORD_OPS: Array<[string, OpCode]> = [
+  ["not in", "nin"], ["in", "in"], ["like", "like"],
+];
+
+const FIXED_COLUMNS = new Set(["owner", "project", "feature", "priority", "status"]);
+const FIXED_OPS = new Set<OpCode>(["eq", "ne", "in"]);
+
+function normalizeLhs(raw: string): { lhs: string; isAttr: boolean } {
+  const t = raw.trim();
+  if (t.startsWith("@")) return { lhs: "@" + t.slice(1).trim().toLowerCase(), isAttr: true };
+  return { lhs: t.toLowerCase(), isAttr: false };
+}
+
+export function parseClause(input: string): Clause {
+  const s = input.trim();
+  if (!s) throw new DSLError("empty clause");
+
+  for (const [word, code] of WORD_OPS) {
+    const re = new RegExp(`^(.+?)\\s+${word.replace(/ /g, "\\s+")}\\s+(.+)$`, "i");
+    const m = re.exec(s);
+    if (m) {
+      const lhs = m[1].trim();
+      const rhs = m[2].trim();
+      if (!lhs || !rhs) throw new DSLError(`malformed clause: ${input}`);
+      const norm = normalizeLhs(lhs);
+      return { lhs: norm.lhs, isAttr: norm.isAttr, op: code, value: rhs };
+    }
+  }
+
+  for (const [tok, code] of SYM_OPS) {
+    const idx = s.indexOf(tok);
+    if (idx <= 0) continue;
+    const lhs = s.slice(0, idx).trim();
+    const rhs = s.slice(idx + tok.length).trim();
+    if (!lhs) throw new DSLError(`missing key in ${input}`);
+    if (!rhs) throw new DSLError(`missing value in ${input}`);
+    const norm = normalizeLhs(lhs);
+    return { lhs: norm.lhs, isAttr: norm.isAttr, op: code, value: rhs };
+  }
+
+  throw new DSLError(
+    `no operator found in "${input}"; expected one of =, !=, >=, <=, >, <, 'in', 'not in'`,
+  );
+}
+
+/** Compile a list of clauses to ``[paramName, value]`` pairs. */
+export function compileClauses(clauses: string[]): Array<[string, string]> {
+  const out: Array<[string, string]> = [];
+  for (const raw of clauses) {
+    if (!raw || !raw.trim()) continue;
+    const c = parseClause(raw);
+    out.push(...compileOne(c, raw));
+  }
+  return out;
+}
+
+function compileOne(c: Clause, raw: string): Array<[string, string]> {
+  if (c.isAttr) {
+    const key = c.lhs.slice(1);
+    if (!key) throw new DSLError(`empty attr key in ${raw}`);
+    return [["attr", `${key}:${c.op}:${c.value}`]];
+  }
+  if (c.lhs === "q") {
+    if (c.op !== "eq") throw new DSLError(`q only supports '=' (got ${c.op})`);
+    return [["q", c.value]];
+  }
+  if (c.lhs === "kind") {
+    if (c.op !== "eq") throw new DSLError(`kind only supports '=' (got ${c.op})`);
+    return [["kind", c.value]];
+  }
+  if (c.lhs === "eta") return compileEta(c, raw);
+  if (FIXED_COLUMNS.has(c.lhs)) {
+    if (!FIXED_OPS.has(c.op)) {
+      throw new DSLError(
+        `operator ${c.op} not supported on ${c.lhs}; ` +
+        `use =, !=, in (or @${c.lhs} for richer ops)`,
+      );
+    }
+    if (c.op === "ne") return [[`not_${c.lhs}`, c.value]];
+    return [[c.lhs, c.value]];
+  }
+  throw new DSLError(
+    `unknown key "${c.lhs}"; prefix arbitrary attrs with '@' (e.g. @${c.lhs}=…)`,
+  );
+}
+
+function compileEta(c: Clause, raw: string): Array<[string, string]> {
+  switch (c.op) {
+    case "gte": return [["eta_after", c.value]];
+    case "lte": return [["eta_before", c.value]];
+    case "gt":
+    case "lt":
+    case "eq":
+    case "ne":
+    case "in":
+    case "nin":
+    case "like":
+      return [["attr", `eta:${c.op}:${c.value}`]];
+    default:
+      throw new DSLError(`unsupported operator on eta: ${c.op} (clause ${raw})`);
+  }
+}
+
+/** Render a clause back into canonical DSL text — used to draw chips. */
+export function renderClause(c: Clause): string {
+  const symbolFor: Partial<Record<OpCode, string>> = {
+    eq: "=", ne: "!=", gte: ">=", lte: "<=", gt: ">", lt: "<",
+  };
+  const sym = symbolFor[c.op];
+  if (sym) return `${c.lhs}${sym}${c.value}`;
+  if (c.op === "in")   return `${c.lhs} in ${c.value}`;
+  if (c.op === "nin")  return `${c.lhs} not in ${c.value}`;
+  if (c.op === "like") return `${c.lhs} like ${c.value}`;
+  return `${c.lhs} ${c.op} ${c.value}`;
+}

--- a/VegaNotes/frontend/src/store/ui.ts
+++ b/VegaNotes/frontend/src/store/ui.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { compileClauses } from "./dsl";
 
 export interface FilterState {
   owner?: string;
@@ -8,6 +9,8 @@ export interface FilterState {
   status?: string;
   hide_done?: boolean;
   q?: string;
+  /** Free-form DSL chips ("@area=fit-val", "eta>=ww18", …). */
+  where?: string[];
 }
 
 interface UIState {
@@ -16,12 +19,57 @@ interface UIState {
   set: (patch: Partial<UIState>) => void;
   patchFilters: (patch: Partial<FilterState>) => void;
   clearFilters: () => void;
+  addChip: (clause: string) => void;
+  removeChip: (index: number) => void;
+  setChips: (chips: string[]) => void;
 }
 
 export const useUI = create<UIState>((set) => ({
-  filters: { hide_done: true },
+  filters: { hide_done: true, where: [] },
   view: "kanban",
   set: (patch) => set(patch),
   patchFilters: (patch) => set((s) => ({ filters: { ...s.filters, ...patch } })),
-  clearFilters: () => set({ filters: { hide_done: true } }),
+  clearFilters: () => set({ filters: { hide_done: true, where: [] } }),
+  addChip: (clause) => set((s) => ({
+    filters: { ...s.filters, where: [...(s.filters.where ?? []), clause] },
+  })),
+  removeChip: (index) => set((s) => {
+    const cur = s.filters.where ?? [];
+    if (index < 0 || index >= cur.length) return {};
+    const next = cur.slice(0, index).concat(cur.slice(index + 1));
+    return { filters: { ...s.filters, where: next } };
+  }),
+  setChips: (chips) => set((s) => ({ filters: { ...s.filters, where: chips } })),
 }));
+
+/**
+ * Reduce the filter state into the parameter map ``api.tasks`` expects.
+ * Fixed columns pass through unchanged; ``where`` chips compile via the
+ * shared DSL and may produce repeated ``attr`` params (encoded as arrays
+ * which the api client then unrolls into URL repeats).
+ */
+export function filtersToParams(
+  f: FilterState,
+): Record<string, string | string[] | boolean | undefined> {
+  const out: Record<string, string | string[] | boolean | undefined> = {
+    owner: f.owner,
+    project: f.project,
+    feature: f.feature,
+    priority: f.priority,
+    status: f.status,
+    hide_done: f.hide_done,
+    q: f.q,
+  };
+  const pairs = compileClauses(f.where ?? []);
+  for (const [k, v] of pairs) {
+    const cur = out[k];
+    if (cur === undefined) {
+      out[k] = v;
+    } else if (Array.isArray(cur)) {
+      cur.push(v);
+    } else {
+      out[k] = [String(cur), v];
+    }
+  }
+  return out;
+}

--- a/VegaNotes/frontend/tests/dsl.test.ts
+++ b/VegaNotes/frontend/tests/dsl.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { compileClauses, parseClause, renderClause, DSLError } from "../src/store/dsl.ts";
+
+describe("parseClause", () => {
+  it.each([
+    ["owner=alice",        { lhs: "owner",   op: "eq",  value: "alice", isAttr: false }],
+    ["project!=internal",  { lhs: "project", op: "ne",  value: "internal", isAttr: false }],
+    ["priority in P0,P1",  { lhs: "priority", op: "in", value: "P0,P1", isAttr: false }],
+    ["priority not in P3", { lhs: "priority", op: "nin", value: "P3",   isAttr: false }],
+    ["eta>=ww18",          { lhs: "eta",     op: "gte", value: "ww18",  isAttr: false }],
+    ["@area=fit-val",      { lhs: "@area",   op: "eq",  value: "fit-val", isAttr: true }],
+    ["@Risk = high",       { lhs: "@risk",   op: "eq",  value: "high",  isAttr: true }],
+    ["status IN open,wip", { lhs: "status",  op: "in",  value: "open,wip", isAttr: false }],
+    ["status=!done",       { lhs: "status",  op: "eq",  value: "!done", isAttr: false }],
+  ] as const)("parses %s", (clause, expected) => {
+    expect(parseClause(clause)).toEqual(expected);
+  });
+
+  it.each(["", "owner", "=alice", "owner=", "owner alice", "  "])(
+    "rejects %p",
+    (bad) => { expect(() => parseClause(bad)).toThrow(DSLError); },
+  );
+});
+
+describe("compileClauses", () => {
+  it("compiles fixed columns", () => {
+    expect(compileClauses(["owner=alice", "status=wip"])).toEqual([
+      ["owner", "alice"], ["status", "wip"],
+    ]);
+  });
+
+  it("inverts fixed columns via not_*", () => {
+    expect(compileClauses(["project!=internal"])).toEqual([["not_project", "internal"]]);
+  });
+
+  it("passes 'in' as csv to fixed columns", () => {
+    expect(compileClauses(["priority in P0,P1"])).toEqual([["priority", "P0,P1"]]);
+  });
+
+  it("compiles arbitrary @attrs", () => {
+    expect(compileClauses(["@area=fit-val", "@risk!=low"])).toEqual([
+      ["attr", "area:eq:fit-val"],
+      ["attr", "risk:ne:low"],
+    ]);
+  });
+
+  it("routes eta range to dedicated date params", () => {
+    expect(compileClauses(["eta>=2026-04-20", "eta<=2026-05-01"])).toEqual([
+      ["eta_after", "2026-04-20"],
+      ["eta_before", "2026-05-01"],
+    ]);
+  });
+
+  it("routes eta equality through generic attr path", () => {
+    expect(compileClauses(["eta=ww17"])).toEqual([["attr", "eta:eq:ww17"]]);
+  });
+
+  it("emits multiple attr params for repeated @key clauses", () => {
+    const out = compileClauses(["@area=a", "@area=b", "@risk=high"]);
+    expect(out.filter(([k]) => k === "attr")).toHaveLength(3);
+  });
+
+  it("rejects range op on non-date fixed column", () => {
+    expect(() => compileClauses(["owner>=alice"])).toThrow(DSLError);
+  });
+
+  it("rejects unknown key without @ prefix", () => {
+    expect(() => compileClauses(["area=fit-val"])).toThrow(DSLError);
+  });
+
+  it("skips empty clauses", () => {
+    expect(compileClauses(["", "  ", "owner=x"])).toEqual([["owner", "x"]]);
+  });
+});
+
+describe("renderClause round-trip", () => {
+  it.each([
+    "owner=alice",
+    "project!=internal",
+    "@area=fit-val",
+    "eta>=ww18",
+    "priority in P0,P1",
+    "priority not in P3",
+  ])("re-renders %s", (clause) => {
+    const c = parseClause(clause);
+    const round = renderClause(c);
+    // Re-parse round-trip equals the parsed canonical form.
+    expect(parseClause(round)).toEqual(c);
+  });
+});

--- a/VegaNotes/frontend/tests/store.test.ts
+++ b/VegaNotes/frontend/tests/store.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useUI, filtersToParams } from "../src/store/ui.ts";
+
+beforeEach(() => {
+  useUI.setState({ filters: { hide_done: true, where: [] } });
+});
+
+describe("UI filter store", () => {
+  it("addChip appends to where", () => {
+    useUI.getState().addChip("@area=fit-val");
+    useUI.getState().addChip("eta>=ww18");
+    expect(useUI.getState().filters.where).toEqual(["@area=fit-val", "eta>=ww18"]);
+  });
+
+  it("removeChip drops by index", () => {
+    useUI.getState().setChips(["a=1", "b=2", "c=3"]);
+    useUI.getState().removeChip(1);
+    expect(useUI.getState().filters.where).toEqual(["a=1", "c=3"]);
+  });
+
+  it("clearFilters resets where to []", () => {
+    useUI.getState().setChips(["@a=1"]);
+    useUI.getState().clearFilters();
+    expect(useUI.getState().filters.where).toEqual([]);
+    expect(useUI.getState().filters.hide_done).toBe(true);
+  });
+});
+
+describe("filtersToParams", () => {
+  it("passes fixed columns through unchanged", () => {
+    const params = filtersToParams({
+      owner: "alice", project: "qry", hide_done: true,
+    });
+    expect(params.owner).toBe("alice");
+    expect(params.project).toBe("qry");
+    expect(params.hide_done).toBe(true);
+  });
+
+  it("compiles where chips into wire params", () => {
+    const params = filtersToParams({
+      where: ["@area=fit-val", "eta>=ww18", "project!=internal"],
+    });
+    expect(params.attr).toBe("area:eq:fit-val");
+    expect(params.eta_after).toBe("ww18");
+    expect(params.not_project).toBe("internal");
+  });
+
+  it("collapses repeated attr params into an array for the api client", () => {
+    const params = filtersToParams({
+      where: ["@area=a", "@area=b", "@risk=high"],
+    });
+    expect(Array.isArray(params.attr)).toBe(true);
+    expect(params.attr).toEqual(["area:eq:a", "area:eq:b", "risk:eq:high"]);
+  });
+
+  it("merges flag-set owner with chip-derived owner into an array", () => {
+    const params = filtersToParams({
+      owner: "alice",
+      where: ["owner=bob"],
+    });
+    expect(params.owner).toEqual(["alice", "bob"]);
+  });
+
+  it("ignores empty chips", () => {
+    const params = filtersToParams({ where: ["", "  ", "owner=x"] });
+    expect(params.owner).toBe("x");
+  });
+});

--- a/VegaNotes/packages/parser-ts/src/parser.ts
+++ b/VegaNotes/packages/parser-ts/src/parser.ts
@@ -41,7 +41,10 @@ function readValue(s: string, i: number, untilHash = false): [string, number] {
     while (j < n) {
       if (s[j] === "#") {
         const m = /^#([a-zA-Z][\w-]*)/.exec(s.slice(j));
-        if (m && isKnown(m[1])) break;
+        // Any attribute-shaped #name terminates the title — even unknown
+        // names, which the parser accepts as generic attrs (issue #38
+        // follow-up). Empty-value attrs are dropped back to text below.
+        if (m) break;
       }
       if (s[j] === "@" && (j === 0 || s[j - 1] === " " || s[j - 1] === "\t" || s[j - 1] === "(" || s[j - 1] === "[")
           && j + 1 < n && /[a-zA-Z_]/.test(s[j + 1])) {
@@ -78,14 +81,25 @@ function lex(line: string): Item[] {
       last = end;
     } else {
       const name = m[2];
-      if (!isKnown(name)) {
-        const end = TOKEN_RE.lastIndex;
+      const known = isKnown(name);
+      // Known status/note read until the next attr; everything else
+      // (including arbitrary unknown attrs) reads a single whitespace-
+      // delimited value. Empty value → keep as prose (`#urgent`).
+      const untilHash = known && (name === "status" || name === "note");
+      const [value, end] = readValue(line, TOKEN_RE.lastIndex, untilHash);
+      if (!value.trim()) {
         out.push({ kind: "text", text: line.slice(start, end) });
+        TOKEN_RE.lastIndex = end;
         last = end;
         continue;
       }
-      const [value, end] = readValue(line, TOKEN_RE.lastIndex, name === "status");
-      out.push({ kind: "attr", name, value: name === "status" ? value.trim() : value, raw: line.slice(start, end), col: start });
+      let outValue = value;
+      if (name === "status") outValue = value.trim();
+      else if (name === "note") {
+        outValue = value.trim();
+        if (!outValue) { TOKEN_RE.lastIndex = end; last = end; continue; }
+      }
+      out.push({ kind: "attr", name, value: outValue, raw: line.slice(start, end), col: start });
       TOKEN_RE.lastIndex = end;
       last = end;
     }
@@ -176,12 +190,14 @@ function isContextOnlyLine(items: Item[]): boolean {
 
 function attachAttr(task: ParsedTask, tok: Token): void {
   const spec = REGISTRY[tok.name];
-  if (tok.name === "status") task.status = (spec.normalize ? String(spec.normalize(tok.value)) : tok.value.trim().toLowerCase()) || "todo";
+  if (tok.name === "status") task.status = (spec && spec.normalize ? String(spec.normalize(tok.value)) : tok.value.trim().toLowerCase()) || "todo";
   if (tok.name === "task" || tok.name === "link") {
     task.refs.push({ kind: tok.name, dst_slug: slugify(tok.value) });
     return;
   }
-  if (spec.multi) {
+  // Unknown attrs (no spec) are treated as generic multi-valued and never normalized.
+  const multi = spec ? spec.multi : true;
+  if (multi) {
     const cur = task.attrs[tok.name];
     if (Array.isArray(cur)) {
       if (!cur.includes(tok.value)) cur.push(tok.value);
@@ -191,7 +207,7 @@ function attachAttr(task: ParsedTask, tok: Token): void {
   } else {
     task.attrs[tok.name] = tok.value;
   }
-  if (spec.normalize) {
+  if (spec && spec.normalize) {
     const norm = spec.normalize(tok.value);
     if (spec.multi) {
       const cur = task.attrs_norm[tok.name];
@@ -209,19 +225,19 @@ function attachAttr(task: ParsedTask, tok: Token): void {
 function mergeInherited(task: ParsedTask, inherited: Record<string, string[]>): void {
   for (const [key, values] of Object.entries(inherited)) {
     const spec = REGISTRY[key];
-    if (!spec) continue;
-    if (spec.multi) {
+    const multi = spec ? spec.multi : true;
+    if (multi) {
       const existing = task.attrs[key];
       const arr: string[] = Array.isArray(existing) ? [...existing] : (existing ? [existing] : []);
       for (const v of values) if (!arr.includes(v)) arr.push(v);
       if (arr.length) {
         task.attrs[key] = arr;
-        if (spec.normalize) task.attrs_norm[key] = arr.map((v) => spec.normalize!(v));
+        if (spec && spec.normalize) task.attrs_norm[key] = arr.map((v) => spec.normalize!(v));
       }
     } else {
       if (!(key in task.attrs) && values.length) {
         task.attrs[key] = values[0];
-        if (spec.normalize) task.attrs_norm[key] = spec.normalize(values[0]);
+        if (spec && spec.normalize) task.attrs_norm[key] = spec.normalize(values[0]);
       }
     }
   }
@@ -230,13 +246,14 @@ function mergeInherited(task: ParsedTask, inherited: Record<string, string[]>): 
 function inheritFromParent(task: ParsedTask, parent: ParsedTask): void {
   for (const [k, v] of Object.entries(parent.attrs)) {
     const spec = REGISTRY[k];
-    if (!spec || !spec.multi) continue;
+    // Unknown attrs are treated as multi-valued; known non-multi attrs are not inherited.
+    if (spec && !spec.multi) continue;
     const existing = task.attrs[k];
     const arr: string[] = Array.isArray(existing) ? [...existing] : (existing ? [existing] : []);
     const items = Array.isArray(v) ? v : [v];
     for (const item of items) if (!arr.includes(item)) arr.push(item);
     task.attrs[k] = arr;
-    if (spec.normalize) task.attrs_norm[k] = arr.map((x) => spec.normalize!(x));
+    if (spec && spec.normalize) task.attrs_norm[k] = arr.map((x) => spec.normalize!(x));
   }
 }
 

--- a/VegaNotes/tools/vn/README.md
+++ b/VegaNotes/tools/vn/README.md
@@ -85,7 +85,7 @@ vn task T-123 status=done priority=P1 eta=2026-W18
 vn task T-456 owners=alice,bob feature=login add-note='shipped behind flag'
 ```
 
-### `vn list [filters]`
+### `vn list [filters]`  (alias: `vn query`)
 
 ```bash
 vn list --owner kushwanth --status open
@@ -93,7 +93,49 @@ vn list --project gfc --priority P0,P1 --hide-done
 vn list -q "carveout" --limit 20
 ```
 
-Outputs a human-readable table; pass `--json` for raw API output.
+Outputs a human-readable table by default; pick another shape with
+`--format`:
+
+| `--format` | description                                                  |
+| ---------- | ------------------------------------------------------------ |
+| `table`    | aligned columns, the default                                 |
+| `json`     | the raw API envelope (same as `--json`)                      |
+| `jsonl`    | one task per line — scriptable                               |
+| `csv`      | header row + data rows                                       |
+| `ids`      | one `T-XXXXXX` (or int PK) per line — pipes into `xargs`     |
+
+Pick + reorder columns with `--columns id,priority,eta,title`; bucket
+the table by any field with `--group-by area`.
+
+#### Query language (`-w` / `--where`)
+
+`vn list` (and the `vn query` alias) accept repeatable `--where` clauses
+that compile to `/api/tasks` parameters. The grammar is `key OP value`:
+
+| Operators (symbolic) | Operators (word)        |
+| -------------------- | ----------------------- |
+| `=`, `!=`            | `in`, `not in`, `like`  |
+| `>=`, `<=`, `>`, `<` |                         |
+
+* **Bare keys** map to fixed columns: `owner`, `project`, `feature`,
+  `priority`, `status`, `eta`, `q`, `kind`. `=`/`!=`/`in` only;
+  inequality compiles to `not_*`.
+* **`@key`** addresses any other `#tag` attribute (e.g. `@area`,
+  `@risk`, `@team`). All operators allowed; range ops require a
+  `value_norm`-populated key (today: `eta`, `priority`).
+* `eta>=ww18` / `eta<=2026-05-01` route to the dedicated date-typed
+  `eta_after` / `eta_before` params; `eta=ww17` (bucket equality)
+  routes through the generic attr path.
+
+```bash
+vn list -w 'owner=alice' -w '@area=fit-val' -w 'eta>=ww18' --sort eta:desc
+vn list -w 'priority in P0,P1' -w 'project!=internal' --limit 50
+vn list -w '@area=fit-val' --format ids | xargs -n1 -I{} vn task {} status=done
+```
+
+Other handy flags (mostly thin convenience over the same wire params):
+`--sort`, `--limit`, `--offset`, `--not-owner`, `--not-project`,
+`--not-feature`, `--not-status`, `--not-priority`, `--kind`.
 
 ### `vn note new --project <p> --title <t>`
 

--- a/VegaNotes/tools/vn/tests/test_cli.py
+++ b/VegaNotes/tools/vn/tests/test_cli.py
@@ -129,6 +129,113 @@ def test_list_filters_passed_through(fake_client):
     assert params["hide_done"] is True
 
 
+def test_list_where_compiles_to_wire_params(fake_client):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": []}
+    cli.main([
+        "list",
+        "-w", "owner=alice",
+        "-w", "@area=fit-val",
+        "-w", "eta>=ww18",
+        "-w", "project!=internal",
+        "--sort", "eta:desc",
+    ])
+    _, _, params, _ = fake_client.calls[-1]
+    assert params["owner"] == "alice"
+    assert params["not_project"] == "internal"
+    assert params["eta_after"] == "ww18"
+    assert params["attr"] == "area:eq:fit-val"
+    assert params["sort"] == "eta:desc"
+
+
+def test_list_multiple_attrs_become_repeated_param(fake_client):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": []}
+    cli.main(["list", "-w", "@area=a", "-w", "@area=b", "-w", "@risk=high"])
+    _, _, params, _ = fake_client.calls[-1]
+    assert isinstance(params["attr"], list)
+    assert "area:eq:a" in params["attr"]
+    assert "area:eq:b" in params["attr"]
+    assert "risk:eq:high" in params["attr"]
+
+
+def test_query_alias_is_list(fake_client):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": []}
+    cli.main(["query", "-w", "owner=alice"])
+    _, path, params, _ = fake_client.calls[-1]
+    assert path == "/api/tasks" and params["owner"] == "alice"
+
+
+def test_list_bad_where_returns_2(fake_client, capsys):
+    rc = cli.main(["list", "-w", "garbage"])
+    assert rc == 2
+    assert "bad --where" in capsys.readouterr().err
+
+
+def test_list_format_csv(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {
+        "tasks": [
+            {"id": 1, "task_uuid": "T-001", "title": "Hi",
+             "status": "todo", "owners": ["a"], "attrs": {"priority": "P1"}},
+        ]
+    }
+    cli.main(["list", "--format", "csv", "--columns", "id,priority,title"])
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    assert lines[0] == "id,priority,title"
+    assert lines[1] == "T-001,P1,Hi"
+
+
+def test_list_format_jsonl(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {
+        "tasks": [{"id": 1, "title": "x"}, {"id": 2, "title": "y"}]
+    }
+    cli.main(["list", "--format", "jsonl"])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert json.loads(out[0])["id"] == 1
+    assert json.loads(out[1])["id"] == 2
+
+
+def test_list_format_ids(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {
+        "tasks": [
+            {"task_uuid": "T-AAA", "id": 5},
+            {"task_uuid": None, "id": 6},
+        ]
+    }
+    cli.main(["list", "--format", "ids"])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == ["T-AAA", "6"]
+
+
+def test_list_columns_reorder(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {
+        "tasks": [{"id": 1, "task_uuid": "T-X", "title": "t", "status": "wip",
+                   "owners": [], "attrs": {"area": "fit-val"}}]
+    }
+    cli.main(["list", "--columns", "title,area,id"])
+    out = capsys.readouterr().out
+    header = out.splitlines()[0]
+    # Title first, then arbitrary attr column from attrs, then id.
+    assert header.split() == ["TITLE", "AREA", "ID"]
+    assert "fit-val" in out
+
+
+def test_list_group_by_buckets_table(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {
+        "tasks": [
+            {"id": 1, "task_uuid": "T-1", "title": "a", "status": "todo",
+             "owners": [], "attrs": {"area": "fit-val"}},
+            {"id": 2, "task_uuid": "T-2", "title": "b", "status": "todo",
+             "owners": [], "attrs": {"area": "fit-val"}},
+            {"id": 3, "task_uuid": "T-3", "title": "c", "status": "todo",
+             "owners": [], "attrs": {"area": "infra"}},
+        ]
+    }
+    cli.main(["list", "--group-by", "area"])
+    out = capsys.readouterr().out
+    assert "== area=fit-val  (2) ==" in out
+    assert "== area=infra  (1) ==" in out
+
+
 def test_list_json_output(fake_client, capsys):
     fake_client.responses[("GET", "/api/tasks")] = {"tasks": [{"id": 1}]}
     cli.main(["--json", "list"])

--- a/VegaNotes/tools/vn/tests/test_query.py
+++ b/VegaNotes/tools/vn/tests/test_query.py
@@ -1,0 +1,125 @@
+"""Unit tests for the vn DSL parser/compiler (`vn/query.py`)."""
+
+from __future__ import annotations
+
+import pytest
+
+from vn.query import DSLError, compile_clauses, parse_clause
+
+
+# ---------- parse_clause ---------------------------------------------------
+
+@pytest.mark.parametrize("clause,expected", [
+    ("owner=alice",         ("owner", "eq", "alice")),
+    ("project!=internal",   ("project", "ne", "internal")),
+    ("priority in P0,P1",   ("priority", "in", "P0,P1")),
+    ("priority not in P3",  ("priority", "nin", "P3")),
+    ("eta>=ww18",           ("eta", "gte", "ww18")),
+    ("eta<=2026-W20",       ("eta", "lte", "2026-W20")),
+    ("eta>ww17",            ("eta", "gt", "ww17")),
+    ("eta<ww22",            ("eta", "lt", "ww22")),
+    ("@area=fit-val",       ("@area", "eq", "fit-val")),
+    ("@Risk = high",        ("@risk", "eq", "high")),
+    # Word op is case-insensitive on the operator but preserves value.
+    ("status IN open,wip",  ("status", "in", "open,wip")),
+    # Status legacy "!done" sentinel — the leading `!` is part of the value,
+    # not the operator, because `=` matches before `!=` only when present.
+    ("status=!done",        ("status", "eq", "!done")),
+    # Owners with dots/dashes survive.
+    ("owner=foo.bar-baz",   ("owner", "eq", "foo.bar-baz")),
+])
+def test_parse_clause(clause, expected):
+    assert parse_clause(clause) == expected
+
+
+@pytest.mark.parametrize("bad", [
+    "",
+    "owner",
+    "=alice",
+    "owner=",
+    "owner alice",          # no operator, no `in`
+    "  ",
+])
+def test_parse_clause_errors(bad):
+    with pytest.raises(DSLError):
+        parse_clause(bad)
+
+
+# ---------- compile_clauses ------------------------------------------------
+
+def test_compile_simple_fixed():
+    pairs = compile_clauses(["owner=alice", "status=wip"])
+    assert ("owner", "alice") in pairs
+    assert ("status", "wip") in pairs
+
+
+def test_compile_fixed_negation():
+    pairs = compile_clauses(["project!=internal"])
+    assert pairs == [("not_project", "internal")]
+
+
+def test_compile_fixed_in_passthrough():
+    # The backend `_split` helper splits comma values, so we pass the
+    # raw csv string straight through as a single param.
+    pairs = compile_clauses(["priority in P0,P1"])
+    assert pairs == [("priority", "P0,P1")]
+
+
+def test_compile_arbitrary_attr():
+    pairs = compile_clauses(["@area=fit-val", "@risk!=low"])
+    assert pairs == [
+        ("attr", "area:eq:fit-val"),
+        ("attr", "risk:ne:low"),
+    ]
+
+
+def test_compile_attr_in_keeps_csv():
+    pairs = compile_clauses(["@area in fit-val,infra"])
+    assert pairs == [("attr", "area:in:fit-val,infra")]
+
+
+def test_compile_eta_range_uses_dedicated_params():
+    pairs = compile_clauses(["eta>=2026-04-20", "eta<=2026-05-01"])
+    assert ("eta_after", "2026-04-20") in pairs
+    assert ("eta_before", "2026-05-01") in pairs
+
+
+def test_compile_eta_eq_routes_through_attr():
+    # `eta=ww17` is a bucket query — the date-typed eta_before/after
+    # params can't express it, so it must take the generic attr path.
+    pairs = compile_clauses(["eta=ww17"])
+    assert pairs == [("attr", "eta:eq:ww17")]
+
+
+def test_compile_eta_strict_gt_lt_uses_attr():
+    pairs = compile_clauses(["eta>ww17", "eta<ww22"])
+    assert ("attr", "eta:gt:ww17") in pairs
+    assert ("attr", "eta:lt:ww22") in pairs
+
+
+def test_compile_q_and_kind_passthrough():
+    pairs = compile_clauses(["q=hello world", "kind=ar"])
+    assert ("q", "hello world") in pairs
+    assert ("kind", "ar") in pairs
+
+
+def test_compile_multiple_attrs_preserved_as_repeats():
+    # Multiple `attr` params must come through as separate pairs so the
+    # urlencoder sends them as repeats.
+    pairs = compile_clauses(["@area=a", "@area=b", "@risk=high"])
+    keys = [k for k, _ in pairs]
+    assert keys.count("attr") == 3
+
+
+def test_compile_skips_empty():
+    assert compile_clauses(["", None, "  ", "owner=x"]) == [("owner", "x")]
+
+
+def test_compile_rejects_range_op_on_owner():
+    with pytest.raises(DSLError):
+        compile_clauses(["owner>=alice"])
+
+
+def test_compile_rejects_unknown_lhs_without_at():
+    with pytest.raises(DSLError):
+        compile_clauses(["area=fit-val"])

--- a/VegaNotes/tools/vn/vn/cli.py
+++ b/VegaNotes/tools/vn/vn/cli.py
@@ -25,6 +25,7 @@ from typing import Any, Optional, Sequence
 from . import __version__
 from .client import ApiError, Client
 from .config import CredentialsError, load_credentials
+from .query import DSLError, compile_clauses
 
 
 # Attribute keys accepted by `vn task ID key=value ...`.
@@ -71,31 +72,41 @@ def _print_json(data: Any) -> None:
     sys.stdout.write("\n")
 
 
-def _print_task_table(tasks: list[dict[str, Any]]) -> None:
+_DEFAULT_COLUMNS = ("id", "status", "priority", "eta", "owners", "title")
+
+
+def _task_field(task: dict[str, Any], col: str) -> str:
+    """Render a single column value for a task as a flat string."""
+    col = col.lower()
+    if col == "id":
+        return str(task.get("task_uuid") or task.get("ref") or task.get("id") or "")
+    if col == "title":
+        return (task.get("title") or "").strip()
+    if col == "status":
+        return str(task.get("status") or "")
+    if col == "owners":
+        owners = task.get("owners") or []
+        return ",".join(owners) if isinstance(owners, list) else str(owners)
+    if col == "features":
+        feats = task.get("features") or []
+        return ",".join(feats) if isinstance(feats, list) else str(feats)
+    attrs = task.get("attrs") or {}
+    val = attrs.get(col)
+    if val is None:
+        # Fall back to top-level keys so e.g. `--columns project,id` works
+        # whether `project` lives on the row or in attrs.
+        val = task.get(col, "")
+    if isinstance(val, list):
+        val = ",".join(str(v) for v in val)
+    return str(val)
+
+
+def _print_task_table(tasks: list[dict[str, Any]], columns: tuple[str, ...] = _DEFAULT_COLUMNS) -> None:
     if not tasks:
         print("(no tasks)")
         return
-    rows = []
-    for t in tasks:
-        attrs = t.get("attrs") or {}
-        prio = attrs.get("priority", "")
-        if isinstance(prio, list):
-            prio = prio[0] if prio else ""
-        eta = attrs.get("eta", "")
-        if isinstance(eta, list):
-            eta = eta[0] if eta else ""
-        # Prefer the T-XXXXXX uuid (what `vn task <ID>` expects); fall
-        # back to the integer PK for unstamped tasks.
-        ident = t.get("task_uuid") or t.get("ref") or t.get("id") or ""
-        rows.append((
-            str(ident),
-            str(t.get("status") or ""),
-            str(prio),
-            str(eta),
-            ",".join(t.get("owners") or []),
-            (t.get("title") or "").strip(),
-        ))
-    headers = ("ID", "STATUS", "PRIO", "ETA", "OWNERS", "TITLE")
+    rows = [tuple(_task_field(t, c) for c in columns) for t in tasks]
+    headers = tuple(c.upper() for c in columns)
     widths = [
         max(len(h), max((len(r[i]) for r in rows), default=0))
         for i, h in enumerate(headers)
@@ -105,6 +116,48 @@ def _print_task_table(tasks: list[dict[str, Any]]) -> None:
     print(fmt.format(*("-" * w for w in widths)))
     for r in rows:
         print(fmt.format(*r))
+
+
+def _print_task_csv(tasks: list[dict[str, Any]], columns: tuple[str, ...]) -> None:
+    import csv
+    w = csv.writer(sys.stdout)
+    w.writerow([c.lower() for c in columns])
+    for t in tasks:
+        w.writerow([_task_field(t, c) for c in columns])
+
+
+def _print_task_jsonl(tasks: list[dict[str, Any]]) -> None:
+    for t in tasks:
+        sys.stdout.write(json.dumps(t, default=str, sort_keys=True))
+        sys.stdout.write("\n")
+
+
+def _print_task_ids(tasks: list[dict[str, Any]]) -> None:
+    for t in tasks:
+        sys.stdout.write(str(t.get("task_uuid") or t.get("id") or ""))
+        sys.stdout.write("\n")
+
+
+def _bucket_value(task: dict[str, Any], field: str) -> str:
+    val = _task_field(task, field)
+    return val or "—"
+
+
+def _print_grouped(
+    tasks: list[dict[str, Any]],
+    field: str,
+    columns: tuple[str, ...],
+) -> None:
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for t in tasks:
+        buckets.setdefault(_bucket_value(t, field), []).append(t)
+    first = True
+    for key in sorted(buckets):
+        if not first:
+            print()
+        first = False
+        print(f"== {field}={key}  ({len(buckets[key])}) ==")
+        _print_task_table(buckets[key], columns)
 
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
@@ -134,7 +187,11 @@ def cmd_task(client: Client, args: argparse.Namespace) -> int:
 
 
 def cmd_list(client: Client, args: argparse.Namespace) -> int:
-    params: dict[str, Any] = {
+    # Start with the explicit fixed-column flags; these win when both a
+    # flag and a `--where` clause set the same key (last-write semantics
+    # via the trailing list extend below).
+    pairs: list[tuple[str, Any]] = []
+    fixed = {
         "owner": args.owner,
         "project": args.project,
         "feature": args.feature,
@@ -144,14 +201,62 @@ def cmd_list(client: Client, args: argparse.Namespace) -> int:
         "eta_after": args.eta_after,
         "hide_done": args.hide_done,
         "q": args.q,
+        "kind": args.kind,
+        "not_owner": args.not_owner,
+        "not_project": args.not_project,
+        "not_feature": args.not_feature,
+        "not_status": args.not_status,
+        "not_priority": args.not_priority,
+        "sort": args.sort,
         "limit": args.limit,
+        "offset": args.offset,
     }
+    for k, v in fixed.items():
+        if v is None or v is False:
+            continue
+        pairs.append((k, v))
+
+    # Compile --where clauses to additional wire pairs.
+    try:
+        pairs.extend(compile_clauses(args.where or []))
+    except DSLError as e:
+        print(f"vn: bad --where clause: {e}", file=sys.stderr)
+        return 2
+
+    # Re-shape into the dict the Client expects (lists for repeats).
+    params: dict[str, Any] = {}
+    for k, v in pairs:
+        if k in params:
+            cur = params[k]
+            if isinstance(cur, list):
+                cur.append(v)
+            else:
+                params[k] = [cur, v]
+        else:
+            params[k] = v
+
     data = client.get("/api/tasks", **params)
     tasks = (data or {}).get("tasks") if isinstance(data, dict) else data
-    if args.json:
+
+    fmt = (args.format or ("json" if args.json else "table")).lower()
+    columns = tuple(c.strip().lower() for c in (args.columns or ",".join(_DEFAULT_COLUMNS)).split(",") if c.strip())
+
+    if fmt == "json":
         _print_json(data)
+    elif fmt == "jsonl":
+        _print_task_jsonl(tasks or [])
+    elif fmt == "csv":
+        _print_task_csv(tasks or [], columns)
+    elif fmt == "ids":
+        _print_task_ids(tasks or [])
+    elif fmt == "table":
+        if args.group_by:
+            _print_grouped(tasks or [], args.group_by.lower(), columns)
+        else:
+            _print_task_table(tasks or [], columns)
     else:
-        _print_task_table(tasks or [])
+        print(f"vn: unknown --format: {fmt}", file=sys.stderr)
+        return 2
     return 0
 
 
@@ -214,18 +319,55 @@ def build_parser() -> argparse.ArgumentParser:
     pt.add_argument("attrs", nargs="*", help="key=value pairs")
     pt.set_defaults(func=cmd_task)
 
+    def _add_list_args(target: argparse.ArgumentParser) -> None:
+        target.add_argument("--owner")
+        target.add_argument("--project")
+        target.add_argument("--feature")
+        target.add_argument("--priority")
+        target.add_argument("--status")
+        target.add_argument("--kind")
+        target.add_argument("--eta-before", dest="eta_before")
+        target.add_argument("--eta-after", dest="eta_after")
+        target.add_argument("--hide-done", action="store_true", dest="hide_done")
+        target.add_argument("-q", "--query", dest="q")
+        target.add_argument("--not-owner", dest="not_owner")
+        target.add_argument("--not-project", dest="not_project")
+        target.add_argument("--not-feature", dest="not_feature")
+        target.add_argument("--not-status", dest="not_status")
+        target.add_argument("--not-priority", dest="not_priority")
+        target.add_argument(
+            "-w", "--where", action="append", default=[],
+            help="DSL clause, repeatable (e.g. --where '@area=fit-val' --where 'eta>=ww18')",
+        )
+        target.add_argument("--sort", help="sort spec, e.g. 'eta:desc' or 'priority,title'")
+        target.add_argument("--limit", type=int)
+        target.add_argument("--offset", type=int)
+        target.add_argument(
+            "--format", choices=("table", "json", "jsonl", "csv", "ids"),
+            help="output format (default: table; 'json' if --json is set)",
+        )
+        target.add_argument(
+            "--columns",
+            help="comma-separated columns for table/csv "
+                 f"(default: {','.join(_DEFAULT_COLUMNS)})",
+        )
+        target.add_argument(
+            "--group-by", dest="group_by",
+            help="bucket the table output by this field (table format only)",
+        )
+        target.set_defaults(func=cmd_list)
+
     pl = sub.add_parser("list", help="list tasks")
-    pl.add_argument("--owner")
-    pl.add_argument("--project")
-    pl.add_argument("--feature")
-    pl.add_argument("--priority")
-    pl.add_argument("--status")
-    pl.add_argument("--eta-before", dest="eta_before")
-    pl.add_argument("--eta-after", dest="eta_after")
-    pl.add_argument("--hide-done", action="store_true", dest="hide_done")
-    pl.add_argument("-q", "--query", dest="q")
-    pl.add_argument("--limit", type=int)
-    pl.set_defaults(func=cmd_list)
+    _add_list_args(pl)
+
+    pq = sub.add_parser(
+        "query",
+        help="alias for 'list' — discoverability for query-style usage",
+        description="Examples:\n"
+                    "  vn query -w 'owner=alice' -w '@area=fit-val' --sort eta:desc\n"
+                    "  vn query -w 'priority in P0,P1' --format ids | xargs -n1 vn task",
+    )
+    _add_list_args(pq)
 
     pn = sub.add_parser("note", help="note operations")
     nsub = pn.add_subparsers(dest="note_command", required=True)

--- a/VegaNotes/tools/vn/vn/query.py
+++ b/VegaNotes/tools/vn/vn/query.py
@@ -1,0 +1,195 @@
+"""Mini-DSL for ``vn list --where``.
+
+Each ``--where`` clause is a single string ``key OP value``; clauses are
+combined with implicit AND. Examples::
+
+    owner=alice
+    project!=internal
+    priority in P0,P1
+    eta>=2026-W18
+    @area=fit-val           # arbitrary TaskAttr key
+    status=!done            # legacy backend "everything but done" convention
+
+The compiler translates clauses into the wire parameters that
+``GET /api/tasks`` already understands (issue #38 follow-up):
+
+* Known fixed columns (``owner``, ``project``, ``feature``, ``priority``,
+  ``status``) compile to ``?key=v`` (or ``?not_key=v`` for ``!=``).
+  Range operators on these are rejected — they don't index a sortable
+  domain.  ``in`` becomes a comma-separated string, which the backend
+  ``_split`` helper already accepts.
+* ``eta`` compiles to ``?eta_before=`` / ``?eta_after=`` for range ops
+  (date-typed) and to ``attr=eta:eq:bucket`` for equality (so ``ww17``
+  buckets work).
+* ``@key`` compiles to ``attr=key:op:value`` (repeatable).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+# Public surface --------------------------------------------------------------
+
+__all__ = ["DSLError", "compile_clauses", "parse_clause"]
+
+
+class DSLError(ValueError):
+    """Raised for any malformed DSL clause."""
+
+
+# Operator table. Order matters — longer prefixes first.
+_OP_TOKENS: list[tuple[str, str]] = [
+    (">=", "gte"),
+    ("<=", "lte"),
+    ("!=", "ne"),
+    ("=",  "eq"),
+    (">",  "gt"),
+    ("<",  "lt"),
+]
+
+# Word operators (whitespace-bounded). Longest first so ``not in`` is
+# tried before ``in``.
+_WORD_OPS: list[tuple[str, str]] = [
+    ("not in", "nin"),
+    ("in",     "in"),
+    ("like",   "like"),
+]
+
+# Fixed columns whose backend params we map to directly.  Anything not
+# in this set must be addressed via the ``@key`` form.
+_FIXED_COLUMNS: frozenset[str] = frozenset({
+    "owner", "project", "feature", "priority", "status",
+})
+
+# Operators allowed on each fixed column.  Range ops only make sense on
+# numeric / date domains; the backend has no "owner > x" semantics.
+_FIXED_OPS: frozenset[str] = frozenset({"eq", "ne", "in"})
+
+
+def parse_clause(clause: str) -> tuple[str, str, str]:
+    """Split a clause into ``(lhs, op_code, value)``.
+
+    ``op_code`` is the canonical short form (``eq``, ``ne``, ``gte``,
+    ``lte``, ``gt``, ``lt``, ``in``, ``nin``, ``like``).
+    """
+    s = clause.strip()
+    if not s:
+        raise DSLError("empty clause")
+
+    # Try word operators first (they need whitespace on both sides so we
+    # don't accidentally split ``project=index``).  Match against the
+    # original string with case-insensitive flag so ``IN`` / ``In`` work.
+    for word, code in _WORD_OPS:
+        m = re.match(
+            rf"^(.+?)\s+{re.escape(word)}\s+(.+)$",
+            s,
+            flags=re.IGNORECASE,
+        )
+        if m:
+            lhs = m.group(1).strip()
+            rhs = m.group(2).strip()
+            if not lhs or not rhs:
+                raise DSLError(f"malformed clause: {clause!r}")
+            return _normalize_lhs(lhs), code, rhs
+
+    # Symbolic operators.
+    for token, code in _OP_TOKENS:
+        idx = s.find(token)
+        if idx <= 0:
+            continue
+        lhs = s[:idx].strip()
+        rhs = s[idx + len(token):].strip()
+        if not lhs:
+            raise DSLError(f"missing key in {clause!r}")
+        if not rhs:
+            raise DSLError(f"missing value in {clause!r}")
+        return _normalize_lhs(lhs), code, rhs
+
+    raise DSLError(
+        f"no operator found in {clause!r}; "
+        "expected one of =, !=, >=, <=, >, <, 'in', 'not in'"
+    )
+
+
+def _normalize_lhs(lhs: str) -> str:
+    """Canonical-case key, preserving the leading ``@`` marker."""
+    lhs = lhs.strip()
+    if lhs.startswith("@"):
+        return "@" + lhs[1:].strip().lower()
+    return lhs.lower()
+
+
+def compile_clauses(clauses: Iterable[str]) -> list[tuple[str, Any]]:
+    """Compile DSL clauses into ``(param_name, value)`` pairs.
+
+    Returns a list of pairs (rather than a dict) because some
+    parameters may legitimately appear more than once — most notably
+    ``attr`` (one entry per arbitrary-attr filter).  The CLI hands the
+    list off to ``Client.request`` which knows how to encode repeats.
+    """
+    out: list[tuple[str, Any]] = []
+    for raw in clauses:
+        if raw is None or not str(raw).strip():
+            continue
+        lhs, op, value = parse_clause(str(raw))
+        out.extend(_compile_one(lhs, op, value, raw))
+    return out
+
+
+# Per-clause compilation -----------------------------------------------------
+
+def _compile_one(lhs: str, op: str, value: str, raw: str) -> list[tuple[str, Any]]:
+    if lhs.startswith("@"):
+        key = lhs[1:]
+        if not key:
+            raise DSLError(f"empty attr key in {raw!r}")
+        return [("attr", f"{key}:{op}:{value}")]
+
+    if lhs == "q":
+        if op != "eq":
+            raise DSLError(f"q only supports '=' (got {op!r})")
+        return [("q", value)]
+
+    if lhs == "kind":
+        if op != "eq":
+            raise DSLError(f"kind only supports '=' (got {op!r})")
+        return [("kind", value)]
+
+    if lhs == "eta":
+        return _compile_eta(op, value, raw)
+
+    if lhs in _FIXED_COLUMNS:
+        if op not in _FIXED_OPS:
+            raise DSLError(
+                f"operator {op!r} not supported on {lhs!r}; "
+                f"use one of =, !=, in (or address it as @{lhs} for richer ops)"
+            )
+        if op == "ne":
+            return [(f"not_{lhs}", value)]
+        # eq + in both produce a single comma-joined string — the backend
+        # `_split` helper already turns that into an OR-list.
+        return [(lhs, value)]
+
+    raise DSLError(
+        f"unknown key {lhs!r}; prefix arbitrary attrs with '@' (e.g. @{lhs}=…)"
+    )
+
+
+def _compile_eta(op: str, value: str, raw: str) -> list[tuple[str, Any]]:
+    # Range ops — defer to the dedicated date-typed params so the
+    # server can compare against real dates rather than the raw string.
+    if op == "gte":
+        return [("eta_after", value)]
+    if op == "lte":
+        return [("eta_before", value)]
+    if op == "gt":
+        # `eta_after` is inclusive; bump-by-day is server-side work, so
+        # for now route strict `>` through the generic attr path which
+        # uses lexicographic comparison on `value_norm`.
+        return [("attr", f"eta:gt:{value}")]
+    if op == "lt":
+        return [("attr", f"eta:lt:{value}")]
+    if op in ("eq", "ne", "in", "nin", "like"):
+        return [("attr", f"eta:{op}:{value}")]
+    raise DSLError(f"unsupported operator on eta: {op!r} (clause {raw!r})")


### PR DESCRIPTION
Implements #94 — end-to-end generic attribute search.

See the issue for full design + acceptance criteria. Highlights:

**Backend** — `/api/tasks` accepts `attr=key:op:value` (eq/ne/in/nin/gte/lte/gt/lt/like/exists/nexists), `not_*` negation, whitelisted `sort`, `limit/offset`, `total`. Parser widened to index arbitrary `#tag value` rows (Py + TS in lockstep; empty-value `#tag` still treated as prose). New `GET /api/attrs` and `GET/PUT /api/me/views`.

**CLI (`vn`)** — `vn/query.py` DSL parser. `vn list`/`vn query` gain `-w/--where`, `--sort`, `--offset`, `--not-*`, `--format {table,json,jsonl,csv,ids}`, `--columns`, `--group-by`.

**GUI** — `src/store/dsl.ts` mirrors the CLI parser. `FilterBar/ChipBar.tsx` (chip input + `@` autocomplete from `/api/attrs`) and `FilterBar/SavedViews.tsx` (dropdown + save/delete via `/api/me/views`). Filter store grows `where: string[]` and `filtersToParams()`.

**Docs** — `api.md`, `command-reference.md`, `tools/vn/README.md`, new `user-guide.md` §9 "Searching".

**Tests** — backend 31 api + 86 parser + 29 new query, vn 57, frontend 39 vitest + tsc clean, TS parser 8.

Examples:
```bash
GET /api/tasks?attr=area:eq:fit-val&attr=risk:eq:high&sort=eta:desc&limit=20
vn list -w 'owner=alice' -w '@area=fit-val' -w 'eta>=ww18' --sort eta:desc
vn list -w '@area=fit-val' --format ids | xargs -n1 -I{} vn task {} status=done
```

Closes #94.