### PR TITLE
feat(vn): surface task / subtask / AR relationships in 'vn list' (closes #98)

### DIFF
--- a/VegaNotes/tools/vn/README.md
+++ b/VegaNotes/tools/vn/README.md
@@ -125,6 +125,42 @@ Outputs an aligned text table by default; pick another shape with
 Pick + reorder columns with `--columns id,priority,eta,title`; bucket
 the table by any field with `--group-by area`.
 
+#### Tasks, subtasks and ARs
+
+Every row carries a `kind` (`task` or `ar`) and a `parent_task_id`. By
+default `vn list` shows only top-level tasks (`kind=task`,
+`parent_task_id IS NULL`). Three knobs surface the rest:
+
+| flag              | what it does                                                               |
+| ----------------- | -------------------------------------------------------------------------- |
+| `--columns …,type,…` | render a `type` column showing `task`, `subtask`, or `ar`              |
+| `--tree`          | include subtasks as `include_children=true`, widen `--kind` to `task,ar`, indent children under their parent in the title column with `├─` / `└─` |
+| `--with-children` | only set `include_children=true` (no rendering change) — for JSON consumers that want nested `children` arrays |
+
+```bash
+# See the kind of each row at a glance:
+vn list --columns id,type,status,priority,title
+
+# Hierarchical view (tasks + ARs, subtasks indented):
+vn list --tree --project ww18
+
+# Same data, but as nested JSON for a downstream script:
+vn list --tree --format json
+# or, without the rendering, just the raw nesting:
+vn list --with-children --format json
+```
+
+Sample tree output:
+
+```
+ID    TYPE     STATUS  PRIORITY  ETA   OWNERS  TITLE
+----  -------  ------  --------  ----  ------  -----------------
+T-1   task     wip     P1        ww18  alice   Refactor parser
+T-1a  subtask  todo                            ├─ add token
+T-1b  subtask  done                            └─ fix lexer
+T-2   ar       open    P2              bob     PR review pending
+```
+
 #### Query language (`-w` / `--where`)
 
 `vn list` (and the `vn query` alias) accept repeatable `--where`

--- a/VegaNotes/tools/vn/tests/test_cli.py
+++ b/VegaNotes/tools/vn/tests/test_cli.py
@@ -243,6 +243,107 @@ def test_list_json_output(fake_client, capsys):
     assert json.loads(out) == {"tasks": [{"id": 1}]}
 
 
+# ---------- task / subtask / AR relationships -----------------------------
+
+def test_type_column_classifies_task_subtask_ar(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": [
+        {"id": 1, "task_uuid": "T-1", "title": "top", "status": "todo",
+         "kind": "task", "parent_task_id": None, "owners": [], "attrs": {}},
+        {"id": 2, "task_uuid": "T-2", "title": "child", "status": "todo",
+         "kind": "task", "parent_task_id": 1, "owners": [], "attrs": {}},
+        {"id": 3, "task_uuid": "T-3", "title": "ar1", "status": "open",
+         "kind": "ar", "parent_task_id": None, "owners": [], "attrs": {}},
+    ]}
+    cli.main(["list", "--columns", "id,type,title"])
+    out = capsys.readouterr().out
+    lines = out.splitlines()
+    # Header + separator + 3 data rows
+    assert lines[0].split() == ["ID", "TYPE", "TITLE"]
+    body = "\n".join(lines[2:])
+    assert "T-1" in body and " task " in body
+    assert "T-2" in body and " subtask " in body
+    assert "T-3" in body and " ar " in body
+
+
+def test_tree_flag_sets_include_children_and_kind(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": []}
+    cli.main(["list", "--tree"])
+    method, path, params, _ = fake_client.calls[0]
+    assert method == "GET" and path == "/api/tasks"
+    assert params.get("include_children") is True
+    # --tree widens kind to task,ar when caller did not pass --kind.
+    assert params.get("kind") == "task,ar"
+
+
+def test_tree_flag_respects_explicit_kind(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": []}
+    cli.main(["list", "--tree", "--kind", "task"])
+    _, _, params, _ = fake_client.calls[0]
+    assert params.get("kind") == "task"
+    assert params.get("include_children") is True
+
+
+def test_tree_renders_subtasks_indented_under_parents(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": [
+        {"id": 1, "task_uuid": "T-1", "title": "Parent A", "status": "wip",
+         "kind": "task", "parent_task_id": None, "owners": [], "attrs": {},
+         "children": [
+             {"id": 11, "task_uuid": "T-1a", "title": "child one",
+              "status": "todo", "kind": "task"},
+             {"id": 12, "task_uuid": "T-1b", "title": "child two",
+              "status": "done", "kind": "task"},
+         ]},
+        {"id": 2, "task_uuid": "T-2", "title": "Lone AR",
+         "status": "open", "kind": "ar", "parent_task_id": None,
+         "owners": [], "attrs": {}, "children": []},
+    ]}
+    cli.main(["list", "--tree", "--columns", "id,type,title"])
+    out = capsys.readouterr().out
+    # Parent A row, two indented children, then the AR.
+    assert "Parent A" in out
+    assert "├─ child one" in out
+    assert "└─ child two" in out
+    assert "Lone AR" in out
+    # Children classify as subtask, AR row classifies as ar.
+    parent_idx = out.index("Parent A")
+    child_idx = out.index("child one")
+    ar_idx = out.index("Lone AR")
+    assert parent_idx < child_idx < ar_idx
+    assert "subtask" in out[child_idx - 30: child_idx]
+    assert "ar" in out[ar_idx - 30: ar_idx]
+
+
+def test_with_children_passes_param_without_flattening(fake_client, capsys):
+    payload = {"tasks": [
+        {"id": 1, "task_uuid": "T-1", "title": "p", "status": "wip",
+         "kind": "task", "parent_task_id": None, "owners": [], "attrs": {},
+         "children": [{"id": 11, "task_uuid": "T-1a", "title": "c",
+                       "status": "todo", "kind": "task"}]},
+    ]}
+    fake_client.responses[("GET", "/api/tasks")] = payload
+    cli.main(["--json", "list", "--with-children"])
+    _, _, params, _ = fake_client.calls[0]
+    assert params.get("include_children") is True
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    # JSON keeps the nested children intact (no flattening for json fmt).
+    assert parsed["tasks"][0]["children"][0]["task_uuid"] == "T-1a"
+
+
+def test_tree_json_keeps_nested_children(fake_client, capsys):
+    payload = {"tasks": [
+        {"id": 1, "task_uuid": "T-1", "title": "p", "status": "wip",
+         "kind": "task", "parent_task_id": None, "owners": [], "attrs": {},
+         "children": [{"id": 11, "task_uuid": "T-1a", "title": "c",
+                       "status": "todo", "kind": "task"}]},
+    ]}
+    fake_client.responses[("GET", "/api/tasks")] = payload
+    cli.main(["list", "--tree", "--format", "json"])
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["tasks"][0]["children"][0]["task_uuid"] == "T-1a"
+
+
 # ---------- note new -------------------------------------------------------
 
 def test_note_new_default_path(fake_client, capsys):

--- a/VegaNotes/tools/vn/vn/cli.py
+++ b/VegaNotes/tools/vn/vn/cli.py
@@ -73,6 +73,18 @@ def _print_json(data: Any) -> None:
 
 
 _DEFAULT_COLUMNS = ("id", "status", "priority", "eta", "owners", "title")
+_TREE_DEFAULT_COLUMNS = ("id", "type", "status", "priority", "eta", "owners", "title")
+
+
+def _task_type(task: dict[str, Any]) -> str:
+    """Classify a task row as 'task', 'subtask' or 'ar'.
+
+    A row with parent_task_id set is always a subtask (regardless of kind);
+    otherwise the value of `kind` (default 'task') is returned.
+    """
+    if task.get("parent_task_id"):
+        return "subtask"
+    return str(task.get("kind") or "task")
 
 
 def _task_field(task: dict[str, Any], col: str) -> str:
@@ -80,8 +92,12 @@ def _task_field(task: dict[str, Any], col: str) -> str:
     col = col.lower()
     if col == "id":
         return str(task.get("task_uuid") or task.get("ref") or task.get("id") or "")
+    if col == "type":
+        return _task_type(task)
     if col == "title":
-        return (task.get("title") or "").strip()
+        title = (task.get("title") or "").strip()
+        prefix = task.get("_indent_prefix")
+        return f"{prefix}{title}" if prefix else title
     if col == "status":
         return str(task.get("status") or "")
     if col == "owners":
@@ -186,6 +202,29 @@ def cmd_task(client: Client, args: argparse.Namespace) -> int:
     return 0
 
 
+def _flatten_tree(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten parents + their `children` into one row list, tagging each
+    child with an `_indent_prefix` so the title column shows the hierarchy.
+
+    Children come straight from the API's `include_children=true` response
+    (a shallow `children` array per parent).  Parents that have no children
+    are returned as-is.
+    """
+    out: list[dict[str, Any]] = []
+    for parent in tasks:
+        parent_copy = dict(parent)
+        parent_copy.pop("_indent_prefix", None)
+        out.append(parent_copy)
+        kids = parent.get("children") or []
+        last = len(kids) - 1
+        for i, c in enumerate(kids):
+            child = dict(c)
+            child["_indent_prefix"] = ("└─ " if i == last else "├─ ")
+            child.setdefault("parent_task_id", parent.get("id"))
+            out.append(child)
+    return out
+
+
 def cmd_list(client: Client, args: argparse.Namespace) -> int:
     # Start with the explicit fixed-column flags; these win when both a
     # flag and a `--where` clause set the same key (last-write semantics
@@ -211,6 +250,14 @@ def cmd_list(client: Client, args: argparse.Namespace) -> int:
         "limit": args.limit,
         "offset": args.offset,
     }
+    tree_mode = bool(getattr(args, "tree", False))
+    with_children = tree_mode or bool(getattr(args, "with_children", False))
+    if with_children:
+        fixed["include_children"] = True
+    if tree_mode and not args.kind:
+        # Tree view is meant to show task / AR rows side-by-side.  Don't
+        # silently override an explicit --kind the caller passed in.
+        fixed["kind"] = "task,ar"
     for k, v in fixed.items():
         if v is None or v is False:
             continue
@@ -239,21 +286,27 @@ def cmd_list(client: Client, args: argparse.Namespace) -> int:
     tasks = (data or {}).get("tasks") if isinstance(data, dict) else data
 
     fmt = (args.format or ("json" if args.json else "table")).lower()
-    columns = tuple(c.strip().lower() for c in (args.columns or ",".join(_DEFAULT_COLUMNS)).split(",") if c.strip())
+    default_cols = _TREE_DEFAULT_COLUMNS if tree_mode else _DEFAULT_COLUMNS
+    columns = tuple(c.strip().lower() for c in (args.columns or ",".join(default_cols)).split(",") if c.strip())
+
+    # Tree mode flattens parents + their `children` into a single row list
+    # for table/csv output.  JSON/JSONL preserve the nested structure so
+    # downstream consumers see the relationship intact.
+    table_rows = _flatten_tree(tasks or []) if tree_mode and fmt in ("table", "csv", "ids") else (tasks or [])
 
     if fmt == "json":
         _print_json(data)
     elif fmt == "jsonl":
         _print_task_jsonl(tasks or [])
     elif fmt == "csv":
-        _print_task_csv(tasks or [], columns)
+        _print_task_csv(table_rows, columns)
     elif fmt == "ids":
-        _print_task_ids(tasks or [])
+        _print_task_ids(table_rows)
     elif fmt == "table":
         if args.group_by:
-            _print_grouped(tasks or [], args.group_by.lower(), columns)
+            _print_grouped(table_rows, args.group_by.lower(), columns)
         else:
-            _print_task_table(tasks or [], columns)
+            _print_task_table(table_rows, columns)
     else:
         print(f"vn: unknown --format: {fmt}", file=sys.stderr)
         return 2
@@ -354,6 +407,16 @@ def build_parser() -> argparse.ArgumentParser:
         target.add_argument(
             "--group-by", dest="group_by",
             help="bucket the table output by this field (table format only)",
+        )
+        target.add_argument(
+            "--tree", action="store_true",
+            help="show parent tasks with their subtasks indented underneath; "
+                 "implies --kind task,ar and include_children=true",
+        )
+        target.add_argument(
+            "--with-children", action="store_true", dest="with_children",
+            help="ask the API to nest subtasks under each parent in the "
+                 "JSON/JSONL response (no rendering change)",
         )
         target.set_defaults(func=cmd_list)
 


### PR DESCRIPTION
Closes #98.

The backend already models all three (`Task.kind` in `{task,ar}`, `Task.parent_task_id` for subtasks) but `vn list` stripped that information. This PR adds three knobs to `vn list` (and `vn query`):

| flag                    | effect                                                                                                                                                                                                                                  |
| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `--columns …,type,…`    | New `type` virtual column rendering `task`, `subtask` (`parent_task_id` set), or `ar`.                                                                                                                                              |
| `--tree`                | Sets `include_children=true`, defaults `--kind` to `task,ar` (unless caller passed `--kind`), and indents children under each parent in the title column with `├─` / `└─`. Default columns become `id,type,status,priority,eta,owners,title`. |
| `--with-children`       | Only sets `include_children=true` — no rendering change, for JSON / JSONL consumers that want the nested `children` arrays intact.                                                                                                       |

### Sample tree output
```
ID    TYPE     STATUS  PRIORITY  ETA   OWNERS  TITLE
----  -------  ------  --------  ----  ------  -----------------
T-1   task     wip     P1        ww18  alice   Refactor parser
T-1a  subtask  todo                            ├─ add token
T-1b  subtask  done                            └─ fix lexer
T-2   ar       open    P2              bob     PR review pending
```

### Notes
- `--tree` flattens the nested response into a row list **only** for table/csv/ids formats. JSON / JSONL preserve the API's nested `children` array, so downstream scripts still see the relationship intact.
- An explicit `--kind` always wins over the `--tree` default.
- No backend, DB, or GUI changes.

### Tests
- 6 new pytest cases in `VegaNotes/tools/vn/tests/test_cli.py` covering the type column classification, `--tree` parameter wiring, indentation, kind-override behaviour, and JSON-passthrough for both `--tree` and `--with-children`.
- `python3 -m pytest VegaNotes/tools/vn/tests -q` → **63/63 pass** (was 57).