### PR TITLE
fix(vn): tree mode dedupe, kind-preserving type column, eta format parity (closes #100)

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -132,24 +132,29 @@ def _task_to_dict(s: Session, t: Task, *, include_children: bool = False) -> dic
         kids = s.exec(
             select(Task).where(Task.parent_task_id == t.id).order_by(Task.line)
         ).all()
-        out["children"] = [
-            {
+        out["children"] = []
+        for c in kids:
+            eta_attr = next(
+                (a for a in s.exec(
+                    select(TaskAttr).where(TaskAttr.task_id == c.id, TaskAttr.key == "eta")
+                ).all()),
+                None,
+            )
+            out["children"].append({
                 "id": c.id,
                 "task_uuid": c.task_uuid,
                 "slug": c.slug,
                 "title": c.title,
                 "status": c.status,
                 "kind": c.kind,
+                "parent_task_id": c.parent_task_id,
                 "line": c.line,
-                "eta": next(
-                    (a.value_norm for a in s.exec(
-                        select(TaskAttr).where(TaskAttr.task_id == c.id, TaskAttr.key == "eta")
-                    ).all()),
-                    None,
-                ),
-            }
-            for c in kids
-        ]
+                # `eta` keeps its historical value_norm shape for back-compat;
+                # `eta_raw` carries the user-typed string so clients (e.g. vn
+                # --tree) can render parents and children consistently.
+                "eta": eta_attr.value_norm if eta_attr else None,
+                "eta_raw": eta_attr.value if eta_attr else None,
+            })
     return out
 
 

--- a/VegaNotes/tools/vn/README.md
+++ b/VegaNotes/tools/vn/README.md
@@ -133,7 +133,7 @@ default `vn list` shows only top-level tasks (`kind=task`,
 
 | flag              | what it does                                                               |
 | ----------------- | -------------------------------------------------------------------------- |
-| `--columns …,type,…` | render a `type` column showing `task`, `subtask`, or `ar`              |
+| `--columns …,type,…` | render a `type` column showing `TASK`, `SUBTASK`, or `AR` (kind always wins — an AR nested under a task still renders as `AR`) |
 | `--tree`          | include subtasks as `include_children=true`, widen `--kind` to `task,ar`, indent children under their parent in the title column with `├─` / `└─` |
 | `--with-children` | only set `include_children=true` (no rendering change) — for JSON consumers that want nested `children` arrays |
 
@@ -153,12 +153,12 @@ vn list --with-children --format json
 Sample tree output:
 
 ```
-ID    TYPE     STATUS  PRIORITY  ETA   OWNERS  TITLE
-----  -------  ------  --------  ----  ------  -----------------
-T-1   task     wip     P1        ww18  alice   Refactor parser
-T-1a  subtask  todo                            ├─ add token
-T-1b  subtask  done                            └─ fix lexer
-T-2   ar       open    P2              bob     PR review pending
+ID    TYPE     STATUS  PRIORITY  ETA     OWNERS  TITLE
+----  -------  ------  --------  ------  ------  ---------------
+T-1   TASK     wip     P1        ww18.2  aboli   Refactor parser
+T-1a  SUBTASK  todo              ww18.2          ├─ add token
+T-1b  AR       open              ww18.2          └─ security AR
+T-2   AR       open    P2                aboli   Lone AR
 ```
 
 #### Query language (`-w` / `--where`)

--- a/VegaNotes/tools/vn/tests/test_cli.py
+++ b/VegaNotes/tools/vn/tests/test_cli.py
@@ -253,16 +253,22 @@ def test_type_column_classifies_task_subtask_ar(fake_client, capsys):
          "kind": "task", "parent_task_id": 1, "owners": [], "attrs": {}},
         {"id": 3, "task_uuid": "T-3", "title": "ar1", "status": "open",
          "kind": "ar", "parent_task_id": None, "owners": [], "attrs": {}},
+        {"id": 4, "task_uuid": "T-4", "title": "nested ar", "status": "open",
+         "kind": "ar", "parent_task_id": 1, "owners": [], "attrs": {}},
     ]}
     cli.main(["list", "--columns", "id,type,title"])
     out = capsys.readouterr().out
     lines = out.splitlines()
-    # Header + separator + 3 data rows
     assert lines[0].split() == ["ID", "TYPE", "TITLE"]
     body = "\n".join(lines[2:])
-    assert "T-1" in body and " task " in body
-    assert "T-2" in body and " subtask " in body
-    assert "T-3" in body and " ar " in body
+    # Values are upper-cased; AR wins over SUBTASK even when nested.
+    assert "T-1" in body and " TASK " in body
+    assert "T-2" in body and " SUBTASK " in body
+    assert "T-3" in body and " AR " in body
+    # T-4: kind=ar AND parent set → still AR, not SUBTASK.
+    assert "T-4" in body
+    t4_line = next(ln for ln in lines if "T-4" in ln)
+    assert " AR " in t4_line and "SUBTASK" not in t4_line
 
 
 def test_tree_flag_sets_include_children_and_kind(fake_client, capsys):
@@ -299,18 +305,76 @@ def test_tree_renders_subtasks_indented_under_parents(fake_client, capsys):
     ]}
     cli.main(["list", "--tree", "--columns", "id,type,title"])
     out = capsys.readouterr().out
-    # Parent A row, two indented children, then the AR.
     assert "Parent A" in out
     assert "├─ child one" in out
     assert "└─ child two" in out
     assert "Lone AR" in out
-    # Children classify as subtask, AR row classifies as ar.
     parent_idx = out.index("Parent A")
     child_idx = out.index("child one")
     ar_idx = out.index("Lone AR")
     assert parent_idx < child_idx < ar_idx
-    assert "subtask" in out[child_idx - 30: child_idx]
-    assert "ar" in out[ar_idx - 30: ar_idx]
+    # Type column is upper-case now.
+    assert "SUBTASK" in out[child_idx - 30: child_idx]
+    assert " AR " in out[ar_idx - 30: ar_idx]
+
+
+def test_tree_dedupes_subtask_returned_at_top_level_and_as_child(fake_client, capsys):
+    """Issue #100 case 1: API returns the subtask twice (top-level + child)
+    when --tree widens kind to task,ar; flatten must drop the duplicate."""
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": [
+        {"id": 1, "task_uuid": "T-1", "title": "Parent", "status": "wip",
+         "kind": "task", "parent_task_id": None, "owners": ["aboli"],
+         "attrs": {}, "children": [
+             {"id": 11, "task_uuid": "T-1a", "title": "Subtask", "status": "todo",
+              "kind": "task", "parent_task_id": 1, "eta": "2026-05-04",
+              "eta_raw": "ww18.2"},
+         ]},
+        # Same subtask, also returned at top level because it matched
+        # --owner=aboli and the kind=task,ar filter doesn't drop subtasks.
+        {"id": 11, "task_uuid": "T-1a", "title": "Subtask", "status": "todo",
+         "kind": "task", "parent_task_id": 1, "owners": ["aboli"],
+         "attrs": {"eta": "ww18.2"}},
+    ]}
+    cli.main(["list", "--tree", "--owner", "aboli", "--columns", "id,type,title"])
+    out = capsys.readouterr().out
+    # T-1a appears exactly once, as a child of T-1.
+    assert out.count("T-1a") == 1
+    assert "├─ Subtask" in out or "└─ Subtask" in out
+
+
+def test_tree_keeps_orphan_subtasks_at_top_level(fake_client, capsys):
+    """If a subtask matches the filter but its parent does NOT appear in
+    the result, keep it at the top level so it isn't lost."""
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": [
+        # Orphan: parent_task_id=99, but task id=99 not in this result.
+        {"id": 11, "task_uuid": "T-1a", "title": "Orphan sub", "status": "todo",
+         "kind": "task", "parent_task_id": 99, "owners": ["aboli"],
+         "attrs": {"eta": "ww18.2"}},
+    ]}
+    cli.main(["list", "--tree", "--owner", "aboli", "--columns", "id,type,title"])
+    out = capsys.readouterr().out
+    assert "T-1a" in out
+    assert "Orphan sub" in out
+
+
+def test_tree_child_eta_renders_raw_value_like_parent(fake_client, capsys):
+    """Issue #100 case 2: child rows used to render normalized
+    (yyyy-mm-dd) eta while parents rendered raw (wwNN); flatten now
+    promotes eta_raw into a synthetic attrs map for parity."""
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": [
+        {"id": 1, "task_uuid": "T-1", "title": "Parent", "status": "wip",
+         "kind": "task", "parent_task_id": None, "owners": [],
+         "attrs": {"eta": "ww18.2"}, "children": [
+             {"id": 11, "task_uuid": "T-1a", "title": "Sub", "status": "todo",
+              "kind": "task", "parent_task_id": 1,
+              "eta": "2026-05-04", "eta_raw": "ww18.2"},
+         ]},
+    ]}
+    cli.main(["list", "--tree", "--columns", "id,eta,title"])
+    out = capsys.readouterr().out
+    # Both rows show the raw ww-format; the normalized form does not leak.
+    assert out.count("ww18.2") == 2
+    assert "2026-05-04" not in out
 
 
 def test_with_children_passes_param_without_flattening(fake_client, capsys):

--- a/VegaNotes/tools/vn/vn/cli.py
+++ b/VegaNotes/tools/vn/vn/cli.py
@@ -77,14 +77,18 @@ _TREE_DEFAULT_COLUMNS = ("id", "type", "status", "priority", "eta", "owners", "t
 
 
 def _task_type(task: dict[str, Any]) -> str:
-    """Classify a task row as 'task', 'subtask' or 'ar'.
+    """Classify a task row as 'TASK', 'SUBTASK' or 'AR'.
 
-    A row with parent_task_id set is always a subtask (regardless of kind);
-    otherwise the value of `kind` (default 'task') is returned.
+    Kind always wins: a row with kind='ar' renders as 'AR' even when it
+    appears nested under a parent task.  'SUBTASK' is reserved for plain
+    tasks that have a parent.  Result is upper-cased for visual scanning.
     """
+    kind = str(task.get("kind") or "task").lower()
+    if kind == "ar":
+        return "AR"
     if task.get("parent_task_id"):
-        return "subtask"
-    return str(task.get("kind") or "task")
+        return "SUBTASK"
+    return kind.upper()
 
 
 def _task_field(task: dict[str, Any], col: str) -> str:
@@ -202,25 +206,68 @@ def cmd_task(client: Client, args: argparse.Namespace) -> int:
     return 0
 
 
+def _normalize_child(child: dict[str, Any], parent_id: Any) -> dict[str, Any]:
+    """Make a slim child dict look like a top-level row for rendering.
+
+    The API's nested children carry only a handful of fields and no
+    `attrs` map; without this _task_field would render some columns
+    differently for parents vs. children (e.g. `eta` falls back to the
+    normalized value_norm rather than the raw user-typed string).
+    Promote the known fields into a synthetic attrs map so the renderer
+    finds the same key on both shapes.
+    """
+    out = dict(child)
+    out.setdefault("parent_task_id", parent_id)
+    if "attrs" not in out:
+        attrs: dict[str, Any] = {}
+        # Prefer the raw user-typed eta (eta_raw, added by the backend
+        # alongside the back-compat normalized `eta`) so parents and
+        # children render the same shape (e.g. "ww18.2" not "2026-05-04").
+        eta_val = out.get("eta_raw") or out.get("eta")
+        if eta_val:
+            attrs["eta"] = eta_val
+        for k in ("status", "priority"):
+            v = out.get(k)
+            if v is not None and v != "":
+                attrs[k] = v
+        out["attrs"] = attrs
+    return out
+
+
 def _flatten_tree(tasks: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Flatten parents + their `children` into one row list, tagging each
     child with an `_indent_prefix` so the title column shows the hierarchy.
 
-    Children come straight from the API's `include_children=true` response
-    (a shallow `children` array per parent).  Parents that have no children
-    are returned as-is.
+    De-duplication: the API returns subtasks twice when --tree is on (once
+    as a top-level row matching kind=task,ar and once as a `children` entry
+    of their parent).  We collect the IDs of all children whose parent is
+    also present in the result, then skip those parents' children at the
+    top level — so each row appears exactly once, preferentially nested
+    under its parent.  Subtasks whose parent did NOT match the filter
+    (orphans) are kept at the top level so they don't disappear.
     """
+    parent_ids = {t.get("id") for t in tasks if t.get("id") is not None}
+    nested_ids: set[Any] = set()
+    for parent in tasks:
+        for c in (parent.get("children") or []):
+            cid = c.get("id")
+            if cid is not None and parent.get("id") in parent_ids:
+                nested_ids.add(cid)
+
     out: list[dict[str, Any]] = []
     for parent in tasks:
+        if parent.get("id") in nested_ids:
+            # This row will be emitted as someone else's child; skip the
+            # duplicate top-level appearance.
+            continue
         parent_copy = dict(parent)
         parent_copy.pop("_indent_prefix", None)
         out.append(parent_copy)
         kids = parent.get("children") or []
         last = len(kids) - 1
         for i, c in enumerate(kids):
-            child = dict(c)
+            child = _normalize_child(c, parent.get("id"))
             child["_indent_prefix"] = ("└─ " if i == last else "├─ ")
-            child.setdefault("parent_task_id", parent.get("id"))
             out.append(child)
     return out
 


### PR DESCRIPTION
Closes #100. Three independent bugs in the `vn list --tree` output found by user testing.

## 1. Subtask duplication
`vn list --tree --owner=aboli` listed the same subtask twice. Root cause: the API returns matching subtasks **both** at the top level (because `--tree` widens `kind` to `task,ar` and `parent_task_id IS NULL` only fires under the separate `top_level_only` flag) **and** nested in their parent's `children` array (`include_children=true`).

`_flatten_tree` now collects the IDs of all children whose parent is also in the top-level result, then drops those parents' duplicate top-level rows. Orphan subtasks (parent not in result) stay at the top level so the filter doesn't silently lose them.

## 2. Eta format mismatch (parent vs. child)
The same subtask rendered with `ww18.2` at the top level but `2026-05-04` as a nested child. Root cause: the API child shape only carries `eta = value_norm`; parent rows include a full `attrs` map whose `eta` is the raw user-typed string. `_task_field` reads `attrs["eta"]` first.

Backend now also exposes `eta_raw` (raw `value`) on each child — backward-compat: existing `eta` field is unchanged. `_normalize_child` in the CLI synthesizes an `attrs` map from `eta_raw` / `status` / `priority` so `_task_field` hits the same code path on both shapes.

## 3. Kind-preserving `type` column + uppercase rendering
`_task_type` previously classified any row with `parent_task_id` set as `subtask`, even when its actual kind was `ar`. Now kind always wins:
- `kind=ar` → `AR` (regardless of parent)
- `kind=task` AND parent set → `SUBTASK`
- `kind=task`, no parent → `TASK`

All values render upper case to match the column header and improve scannability.

## Sample output (after fix)
```
ID    TYPE     STATUS  PRIORITY  ETA     OWNERS  TITLE
----  -------  ------  --------  ------  ------  ---------------
T-1   TASK     wip     P1        ww18.2  aboli   Refactor parser
T-1a  SUBTASK  todo              ww18.2          ├─ add token
T-1b  AR       open              ww18.2          └─ security AR
T-2   AR       open    P2                aboli   Lone AR
```

## Tests
- 3 new pytest cases in `VegaNotes/tools/vn/tests/test_cli.py`:
  - `test_tree_dedupes_subtask_returned_at_top_level_and_as_child`
  - `test_tree_keeps_orphan_subtasks_at_top_level`
  - `test_tree_child_eta_renders_raw_value_like_parent`
- Updated `test_type_column_classifies_task_subtask_ar` for uppercase + AR-with-parent case.
- Updated `test_tree_renders_subtasks_indented_under_parents` for uppercase.
- `python3 -m pytest VegaNotes/tools/vn/tests -q` → **66/66 pass** (was 63).
- Backend: `pytest backend/tests/api -q` → **60/60 pass** (one pre-existing date-sensitive test deselected as before).