### PR TITLE
vn: add `show` inspector + `api` escape hatch (closes #106)

### DIFF
--- a/VegaNotes/tools/vn/README.md
+++ b/VegaNotes/tools/vn/README.md
@@ -72,7 +72,7 @@ Lookup order (first hit wins):
 `vn` always takes a subcommand first:
 
 ```
-vn [GLOBAL FLAGS] <task|list|query|note|whoami> [...]
+vn [GLOBAL FLAGS] <task|list|query|note|whoami|show|api> [...]
 ```
 
 > **Heads-up:** every operation lives under a subcommand. `vn --project
@@ -220,6 +220,45 @@ The slug uses the same lowercase-kebab rule as the rest of VegaNotes
 ### `vn whoami`
 
 Prints the authenticated user (and `(admin)` if applicable).
+
+### `vn show <resource>` — read-only inspector
+
+Browse the database without curl-ing the API by hand. Every resource maps
+to an existing endpoint and respects `--format {table,json,jsonl,csv,ids}`
+plus `--columns col1,col2,…` where applicable.
+
+```bash
+vn show projects                  # all projects you can see (name, role)
+vn show projects ww18             # members + notes for one project
+vn show users                     # known usernames
+vn show features                  # feature names
+vn show features ic               # task table for feature 'ic'
+vn show attrs                     # attribute keys the DB has ever seen
+vn show notes                     # id / path / etag for every note
+vn show note 42                   # one note (header); add --full for body
+vn show note projects/ww18/foo.md # path also works
+vn show tree                      # indented project → note → task tree
+vn show agenda --owner alice --days 14
+vn show task T-ABC123             # one task as a row
+vn show links T-ABC123            # cards linked to/from this one
+vn show me                        # self info + saved views
+vn show search 'fit-val'          # cross-resource search
+```
+
+### `vn api METHOD /api/path` — generic HTTP escape hatch
+
+For endpoints `vn show` doesn't cover, prototyping new endpoints, or
+exercising admin routes. Auth is reused from your profile.
+
+```bash
+vn api GET  /api/admin/users
+vn api GET  /api/tasks --query 'project=ww18' --query 'kind=ar'
+vn api POST /api/projects --json-body '{"name":"ww19"}'
+vn api PATCH /api/tasks/T-ABC123 --json-body '{"status":"done"}'
+```
+
+Output formats: `--format json` (default), `jsonl`, `raw`. HTTP errors
+print `HTTP <status>: <body>` to stderr and exit `4` (4xx) or `5` (5xx).
 
 ## Global flags
 

--- a/VegaNotes/tools/vn/tests/test_cli.py
+++ b/VegaNotes/tools/vn/tests/test_cli.py
@@ -488,3 +488,310 @@ def test_credentials_file(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "CREDENTIALS_PATH", cred)
     c = config.load_credentials()
     assert (c.url, c.user, c.password) == ("http://x", "a", "b")
+
+
+# ---------- vn show <resource> --------------------------------------------
+
+def test_show_projects_table(fake_client, capsys):
+    fake_client.responses[("GET", "/api/projects")] = [
+        {"name": "ww17", "role": "manager"},
+        {"name": "ww18", "role": "member"},
+    ]
+    rc = cli.main(["show", "projects"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "ww17" in out and "manager" in out
+    assert "ww18" in out and "member" in out
+
+
+def test_show_projects_detail_combines_members_and_notes(fake_client, capsys):
+    fake_client.responses[("GET", "/api/projects/ww18/members")] = [
+        {"user_name": "alice", "role": "manager"},
+    ]
+    fake_client.responses[("GET", "/api/projects/ww18/notes")] = [
+        {"id": 1, "path": "ww18/standup.md", "title": "Standup"},
+    ]
+    rc = cli.main(["show", "projects", "ww18"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "== project ww18 ==" in out
+    assert "alice" in out and "manager" in out
+    assert "ww18/standup.md" in out
+
+
+def test_show_users_lifts_string_list(fake_client, capsys):
+    fake_client.responses[("GET", "/api/users")] = ["alice", "bob"]
+    cli.main(["show", "users"])
+    out = capsys.readouterr().out
+    assert "NAME" in out and "alice" in out and "bob" in out
+
+
+def test_show_users_json_passes_raw_envelope(fake_client, capsys):
+    fake_client.responses[("GET", "/api/users")] = ["alice", "bob"]
+    cli.main(["--json", "show", "users"])
+    out = capsys.readouterr().out
+    assert json.loads(out) == ["alice", "bob"]
+
+
+def test_show_features_list_then_detail(fake_client, capsys):
+    fake_client.responses[("GET", "/api/features")] = ["ic", "lsq"]
+    cli.main(["show", "features"])
+    out = capsys.readouterr().out
+    assert "ic" in out and "lsq" in out
+
+    fake_client.responses[("GET", "/api/features/ic/tasks")] = {
+        "feature": "ic",
+        "tasks": [{"id": 1, "task_uuid": "T-1", "title": "carveout",
+                   "status": "wip", "owners": ["alice"], "attrs": {}}],
+        "aggregations": {"owners": ["alice"], "projects": ["gfc"],
+                         "status_breakdown": {"wip": 1}, "eta_range": [None, None]},
+    }
+    capsys.readouterr()
+    cli.main(["show", "features", "ic"])
+    out = capsys.readouterr().out
+    assert "== feature ic" in out
+    assert "T-1" in out and "carveout" in out
+    assert "owners:   alice" in out
+
+
+def test_show_attrs_renders_key_count_samples(fake_client, capsys):
+    fake_client.responses[("GET", "/api/attrs")] = [
+        {"key": "eta", "count": 250, "sample_values": ["ww18", "ww19"]},
+        {"key": "priority", "count": 248, "sample_values": ["P0", "P1"]},
+    ]
+    cli.main(["show", "attrs"])
+    out = capsys.readouterr().out
+    assert "eta" in out and "250" in out and "ww18,ww19" in out
+    assert "priority" in out and "P0,P1" in out
+
+
+def test_show_notes_list_and_detail(fake_client, capsys):
+    fake_client.responses[("GET", "/api/notes")] = [
+        {"id": 1, "path": "ww18/standup.md", "title": "Standup", "updated_at": "2026-04-01"},
+    ]
+    cli.main(["show", "notes"])
+    out = capsys.readouterr().out
+    assert "ww18/standup.md" in out and "Standup" in out
+
+    fake_client.responses[("GET", "/api/notes/1")] = {
+        "id": 1, "path": "ww18/standup.md", "title": "Standup",
+        "etag": "abc123", "body_md": "# Standup\n\nline1\nline2\n", "updated_at": "2026-04-01",
+    }
+    capsys.readouterr()
+    cli.main(["show", "notes", "1"])
+    out = capsys.readouterr().out
+    assert "id:    1" in out
+    assert "path:  ww18/standup.md" in out
+    assert "etag:  abc123" in out
+    # Preview shows the body for short notes.
+    assert "# Standup" in out and "line1" in out
+
+
+def test_show_notes_path_resolves_via_listing(fake_client, capsys):
+    fake_client.responses[("GET", "/api/notes")] = [
+        {"id": 7, "path": "ww18/standup.md", "title": "S"},
+    ]
+    fake_client.responses[("GET", "/api/notes/7")] = {
+        "id": 7, "path": "ww18/standup.md", "title": "S",
+        "etag": "x", "body_md": "body\n", "updated_at": "x",
+    }
+    cli.main(["show", "notes", "ww18/standup.md"])
+    out = capsys.readouterr().out
+    assert "id:    7" in out
+    assert "body" in out
+
+
+def test_show_notes_full_dumps_entire_body(fake_client, capsys):
+    big = "\n".join(f"line {i}" for i in range(50))
+    fake_client.responses[("GET", "/api/notes/1")] = {
+        "id": 1, "path": "x.md", "title": "X", "etag": "e",
+        "body_md": big, "updated_at": "x",
+    }
+    cli.main(["show", "notes", "1", "--full"])
+    out = capsys.readouterr().out
+    assert "line 0" in out and "line 49" in out
+    assert "lines total" not in out  # truncation hint suppressed by --full
+
+
+def test_show_tree_indents_notes_under_projects(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tree")] = [
+        {"project": "ww18", "role": "member", "notes": [
+            {"id": 1, "path": "ww18/a.md"},
+            {"id": 2, "path": "ww18/b.md"},
+        ]},
+    ]
+    cli.main(["show", "tree"])
+    out = capsys.readouterr().out
+    assert "ww18  [member]  (2 notes)" in out
+    assert "├─ ww18/a.md" in out
+    assert "└─ ww18/b.md" in out
+
+
+def test_show_agenda_passes_owner_and_days(fake_client, capsys):
+    fake_client.responses[("GET", "/api/agenda")] = {
+        "window": {"start": "2026-04-01", "end": "2026-04-08", "days": 7},
+        "by_day": {
+            "2026-04-02": [{"id": 1, "task_uuid": "T-1", "title": "x",
+                            "status": "todo", "owners": ["alice"], "attrs": {}}],
+        },
+    }
+    cli.main(["show", "agenda", "--owner", "alice", "--days", "7"])
+    _, _, params, _ = fake_client.calls[0]
+    assert params == {"owner": "alice", "days": 7}
+    out = capsys.readouterr().out
+    assert "agenda 2026-04-01 → 2026-04-08" in out
+    assert "== 2026-04-02" in out and "T-1" in out
+
+
+def test_show_task_renders_single_row(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks/T-1")] = {
+        "id": 1, "task_uuid": "T-1", "title": "x", "status": "wip",
+        "owners": ["a"], "attrs": {},
+    }
+    cli.main(["show", "task", "T-1"])
+    out = capsys.readouterr().out
+    assert "T-1" in out and "wip" in out
+
+
+def test_show_task_requires_target(fake_client, capsys):
+    rc = cli.main(["show", "task"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "requires a task ref" in err
+
+
+def test_show_links_lists_link_rows(fake_client, capsys):
+    fake_client.responses[("GET", "/api/cards/T-1/links")] = {
+        "task_id": 1, "task_uuid": "T-1", "slug": "x",
+        "links": [
+            {"other_slug": "y", "kind": "blocks", "direction": "out"},
+            {"other_slug": "z", "kind": "task", "direction": "in"},
+        ],
+    }
+    cli.main(["show", "links", "T-1"])
+    out = capsys.readouterr().out
+    assert "y" in out and "blocks" in out and "out" in out
+    assert "z" in out and "in" in out
+
+
+def test_show_me_combines_user_and_views(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me")] = {"name": "alice", "is_admin": True}
+    fake_client.responses[("GET", "/api/me/views")] = {"my-blocked": "status=blocked"}
+    cli.main(["show", "me"])
+    out = capsys.readouterr().out
+    assert "name: alice (admin)" in out
+    assert "saved views: 1" in out
+    assert "- my-blocked" in out
+
+
+def test_show_search_passes_q_param(fake_client, capsys):
+    fake_client.responses[("GET", "/api/search")] = [
+        {"id": 1, "path": "ww18/x.md", "title": "X"},
+    ]
+    cli.main(["show", "search", "carveout"])
+    _, _, params, _ = fake_client.calls[0]
+    assert params == {"q": "carveout"}
+    out = capsys.readouterr().out
+    assert "ww18/x.md" in out and "X" in out
+
+
+# ---------- vn api (escape hatch) -----------------------------------------
+
+def test_api_get_default_format_is_json(fake_client, capsys):
+    fake_client.responses[("GET", "/api/admin/users")] = [
+        {"name": "alice"}, {"name": "bob"},
+    ]
+    rc = cli.main(["api", "GET", "/api/admin/users"])
+    assert rc == 0
+    parsed = json.loads(capsys.readouterr().out)
+    assert parsed == [{"name": "alice"}, {"name": "bob"}]
+
+
+def test_api_path_without_leading_slash_is_normalized(fake_client, capsys):
+    fake_client.responses[("GET", "/api/projects")] = []
+    cli.main(["api", "GET", "api/projects"])
+    method, path, _, _ = fake_client.calls[0]
+    assert method == "GET" and path == "/api/projects"
+
+
+def test_api_query_repeatable_and_amp_separated(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": []}
+    cli.main([
+        "api", "GET", "/api/tasks",
+        "--query", "project=ww18",
+        "--query", "kind=ar&owner=alice",
+    ])
+    _, _, params, _ = fake_client.calls[0]
+    assert params == {"project": "ww18", "kind": "ar", "owner": "alice"}
+
+
+def test_api_query_repeated_key_becomes_list(fake_client, capsys):
+    fake_client.responses[("GET", "/api/tasks")] = {"tasks": []}
+    cli.main([
+        "api", "GET", "/api/tasks",
+        "--query", "attr=area:eq:fit-val",
+        "--query", "attr=risk:eq:high",
+    ])
+    _, _, params, _ = fake_client.calls[0]
+    assert params["attr"] == ["area:eq:fit-val", "risk:eq:high"]
+
+
+def test_api_post_with_json_body(fake_client, capsys):
+    fake_client.responses[("POST", "/api/projects")] = {"name": "ww19"}
+    rc = cli.main([
+        "api", "POST", "/api/projects",
+        "--json-body", '{"name": "ww19"}',
+    ])
+    assert rc == 0
+    method, path, params, body = fake_client.calls[0]
+    assert method == "POST" and path == "/api/projects" and body == {"name": "ww19"}
+
+
+def test_api_bad_json_body_returns_2(fake_client, capsys):
+    rc = cli.main(["api", "POST", "/api/x", "--json-body", "{not json"])
+    assert rc == 2
+    assert "not valid JSON" in capsys.readouterr().err
+
+
+def test_api_bad_query_returns_2(fake_client, capsys):
+    rc = cli.main(["api", "GET", "/api/x", "--query", "no_equals"])
+    assert rc == 2
+    assert "key=value" in capsys.readouterr().err
+
+
+def test_api_jsonl_format_for_list_response(fake_client, capsys):
+    fake_client.responses[("GET", "/api/notes")] = [
+        {"id": 1, "path": "a.md"}, {"id": 2, "path": "b.md"},
+    ]
+    cli.main(["api", "GET", "/api/notes", "--format", "jsonl"])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 2
+    assert json.loads(out[0])["id"] == 1
+    assert json.loads(out[1])["id"] == 2
+
+
+def test_api_http_error_maps_to_exit_4(monkeypatch, capsys):
+    from vn.client import ApiError
+
+    class ErrClient:
+        def request(self, *a, **k):
+            raise ApiError(404, '{"detail":"not found"}')
+        def get(self, p, **kw): return self.request("GET", p, params=kw)
+
+    monkeypatch.setattr(cli, "Client", lambda *a, **k: ErrClient())
+    rc = cli.main(["api", "GET", "/api/missing"])
+    assert rc == 4
+    assert "HTTP 404" in capsys.readouterr().err
+
+
+def test_api_http_5xx_maps_to_exit_5(monkeypatch, capsys):
+    from vn.client import ApiError
+
+    class ErrClient:
+        def request(self, *a, **k):
+            raise ApiError(500, "boom")
+        def get(self, p, **kw): return self.request("GET", p, params=kw)
+
+    monkeypatch.setattr(cli, "Client", lambda *a, **k: ErrClient())
+    rc = cli.main(["api", "GET", "/api/x"])
+    assert rc == 5

--- a/VegaNotes/tools/vn/vn/cli.py
+++ b/VegaNotes/tools/vn/vn/cli.py
@@ -396,6 +396,365 @@ def cmd_whoami(client: Client, args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# `vn show <resource>` — read-only inspector for the rest of the API.
+# ---------------------------------------------------------------------------
+#
+# Goal: every endpoint the GUI calls should be reachable from the terminal
+# without resorting to raw curl, so debugging "what's actually in the DB?"
+# stops requiring a SQLite shell.  Each resource maps to one (or two) of
+# the existing GET endpoints; rendering goes through one generic table
+# helper plus the existing `_print_json` / CSV / JSONL helpers.
+#
+# All `vn show` subcommands are read-only.
+
+def _print_records_table(
+    records: list[dict[str, Any]],
+    columns: tuple[str, ...],
+) -> None:
+    """Render a list of arbitrary dicts as an aligned text table.
+
+    Unknown columns render as an empty string.  Lists are joined with
+    commas; everything else is stringified.  Mirrors `_print_task_table`
+    but is task-agnostic so `vn show projects/users/...` can reuse it.
+    """
+    if not records:
+        print("(empty)")
+        return
+
+    def _val(rec: dict[str, Any], col: str) -> str:
+        v = rec.get(col)
+        if v is None:
+            return ""
+        if isinstance(v, list):
+            return ",".join(str(x) for x in v)
+        if isinstance(v, dict):
+            return json.dumps(v, default=str, sort_keys=True)
+        return str(v)
+
+    rows = [tuple(_val(r, c) for c in columns) for r in records]
+    headers = tuple(c.upper() for c in columns)
+    widths = [
+        max(len(h), max((len(r[i]) for r in rows), default=0))
+        for i, h in enumerate(headers)
+    ]
+    fmt = "  ".join("{:<" + str(w) + "}" for w in widths)
+    print(fmt.format(*headers))
+    print(fmt.format(*("-" * w for w in widths)))
+    for r in rows:
+        print(fmt.format(*r))
+
+
+def _print_records_csv(
+    records: list[dict[str, Any]],
+    columns: tuple[str, ...],
+) -> None:
+    import csv
+    w = csv.writer(sys.stdout)
+    w.writerow([c.lower() for c in columns])
+    for r in records:
+        w.writerow([
+            ",".join(str(x) for x in v) if isinstance(v, list)
+            else "" if v is None else str(v)
+            for v in (r.get(c) for c in columns)
+        ])
+
+
+def _emit_records(
+    args: argparse.Namespace,
+    records: list[dict[str, Any]],
+    default_columns: tuple[str, ...],
+    raw: Any | None = None,
+) -> None:
+    """Render `records` according to --format / --columns / --json.
+
+    `raw` is the API envelope to emit when --format=json (so callers that
+    receive {"foo": [...]} can pass the dict verbatim instead of unwrapped
+    records).  Defaults to `records` when not supplied.
+    """
+    fmt = (getattr(args, "format", None) or ("json" if args.json else "table")).lower()
+    cols = getattr(args, "columns", None)
+    columns = tuple(c.strip().lower() for c in (cols or ",".join(default_columns)).split(",") if c.strip())
+    if fmt == "json":
+        _print_json(raw if raw is not None else records)
+    elif fmt == "jsonl":
+        for r in records:
+            sys.stdout.write(json.dumps(r, default=str, sort_keys=True))
+            sys.stdout.write("\n")
+    elif fmt == "csv":
+        _print_records_csv(records, columns)
+    elif fmt == "ids":
+        for r in records:
+            sys.stdout.write(str(r.get("id") or r.get("name") or r.get("path") or ""))
+            sys.stdout.write("\n")
+    else:
+        _print_records_table(records, columns)
+
+
+def _wrap_string_list(items: list[Any], key: str) -> list[dict[str, Any]]:
+    """Some endpoints return a flat ['name1', 'name2', ...] list; lift it
+    into [{key: 'name1'}, ...] so the generic renderer can show it."""
+    return [{key: x} for x in items]
+
+
+def cmd_show(client: Client, args: argparse.Namespace) -> int:
+    resource = args.resource
+
+    if resource == "projects":
+        if args.target:
+            # Project detail: members + notes for one project.
+            members = client.get(f"/api/projects/{args.target}/members") or []
+            notes = client.get(f"/api/projects/{args.target}/notes") or []
+            envelope = {"project": args.target, "members": members, "notes": notes}
+            if (args.format or ("json" if args.json else "table")).lower() == "json":
+                _print_json(envelope)
+                return 0
+            print(f"== project {args.target} ==")
+            print(f"members ({len(members)}):")
+            _print_records_table(members, ("user_name", "role"))
+            print()
+            print(f"notes ({len(notes)}):")
+            _print_records_table(notes, ("id", "path", "title"))
+            return 0
+        data = client.get("/api/projects") or []
+        _emit_records(args, data, ("name", "role"))
+        return 0
+
+    if resource == "users":
+        data = client.get("/api/users") or []
+        # /api/users returns ['name1', 'name2'] — wrap for table rendering.
+        records = _wrap_string_list(data, "name") if data and isinstance(data[0], str) else data
+        _emit_records(args, records, ("name",), raw=data)
+        return 0
+
+    if resource == "features":
+        if args.target:
+            data = client.get(f"/api/features/{args.target}/tasks") or {}
+            tasks = data.get("tasks", [])
+            fmt = (args.format or ("json" if args.json else "table")).lower()
+            if fmt == "json":
+                _print_json(data)
+                return 0
+            cols = tuple(c.strip().lower() for c in (args.columns or ",".join(_DEFAULT_COLUMNS)).split(",") if c.strip())
+            print(f"== feature {args.target}  ({len(tasks)} tasks) ==")
+            _print_task_table(tasks, cols)
+            aggs = data.get("aggregations") or {}
+            if aggs and fmt == "table":
+                print()
+                print(f"owners:   {','.join(aggs.get('owners') or [])}")
+                print(f"projects: {','.join(aggs.get('projects') or [])}")
+                print(f"status:   {aggs.get('status_breakdown') or {}}")
+            return 0
+        data = client.get("/api/features") or []
+        records = _wrap_string_list(data, "name") if data and isinstance(data[0], str) else data
+        _emit_records(args, records, ("name",), raw=data)
+        return 0
+
+    if resource == "attrs":
+        data = client.get("/api/attrs") or []
+        # Each row: {key, count, sample_values}.  Render samples as joined.
+        _emit_records(args, data, ("key", "count", "sample_values"))
+        return 0
+
+    if resource == "notes":
+        if args.target:
+            # Single note: id (int) or path (string).
+            t = args.target
+            if t.isdigit():
+                data = client.get(f"/api/notes/{t}") or {}
+            else:
+                # /api/notes/{id} only accepts an int; resolve path -> id first.
+                listing = client.get("/api/notes") or []
+                match = next((n for n in listing if n.get("path") == t), None)
+                if not match:
+                    print(f"vn: note not found: {t}", file=sys.stderr)
+                    return 1
+                data = client.get(f"/api/notes/{match['id']}") or {}
+            if args.json or (args.format or "").lower() == "json":
+                _print_json(data)
+                return 0
+            print(f"id:    {data.get('id')}")
+            print(f"path:  {data.get('path')}")
+            print(f"title: {data.get('title')}")
+            print(f"etag:  {data.get('etag')}")
+            body = data.get("body_md") or ""
+            if args.full:
+                print()
+                print(body)
+            else:
+                preview = "\n".join(body.splitlines()[:20])
+                print()
+                print(preview)
+                if body.count("\n") > 20:
+                    print(f"... ({body.count(chr(10)) + 1} lines total — pass --full to see all)")
+            return 0
+        data = client.get("/api/notes") or []
+        _emit_records(args, data, ("id", "path", "title", "updated_at"))
+        return 0
+
+    if resource == "tree":
+        data = client.get("/api/tree") or []
+        if args.json or (args.format or "").lower() == "json":
+            _print_json(data)
+            return 0
+        for proj in data:
+            name = proj.get("project") or "(loose)"
+            role = proj.get("role") or "?"
+            notes = proj.get("notes") or []
+            print(f"{name}  [{role}]  ({len(notes)} notes)")
+            for i, n in enumerate(notes):
+                glyph = "└─" if i == len(notes) - 1 else "├─"
+                print(f"  {glyph} {n.get('path')}  (id={n.get('id')})")
+        return 0
+
+    if resource == "agenda":
+        params: dict[str, Any] = {}
+        if args.owner:
+            params["owner"] = args.owner
+        if args.days is not None:
+            params["days"] = args.days
+        data = client.get("/api/agenda", **params) or {}
+        if args.json or (args.format or "").lower() == "json":
+            _print_json(data)
+            return 0
+        win = data.get("window") or {}
+        print(f"agenda {win.get('start')} → {win.get('end')}  ({win.get('days')} days)")
+        for day in sorted((data.get("by_day") or {}).keys()):
+            tasks = data["by_day"][day]
+            print()
+            print(f"== {day}  ({len(tasks)}) ==")
+            _print_task_table(tasks, _DEFAULT_COLUMNS)
+        return 0
+
+    if resource == "task":
+        if not args.target:
+            print("vn: 'show task' requires a task ref (e.g. T-XXXXXX)", file=sys.stderr)
+            return 2
+        data = client.get(f"/api/tasks/{args.target}") or {}
+        if args.json or (args.format or "").lower() == "json":
+            _print_json(data)
+            return 0
+        _print_task_table([data] if data else [], _DEFAULT_COLUMNS)
+        return 0
+
+    if resource == "links":
+        if not args.target:
+            print("vn: 'show links' requires a task ref", file=sys.stderr)
+            return 2
+        data = client.get(f"/api/cards/{args.target}/links") or {}
+        links = data.get("links") or []
+        _emit_records(args, links, ("other_slug", "kind", "direction"), raw=data)
+        return 0
+
+    if resource == "me":
+        data = client.get("/api/me") or {}
+        views = client.get("/api/me/views") or {}
+        envelope = {"me": data, "saved_views": views}
+        if args.json or (args.format or "").lower() == "json":
+            _print_json(envelope)
+            return 0
+        tag = " (admin)" if data.get("is_admin") else ""
+        print(f"name: {data.get('name')}{tag}")
+        print(f"saved views: {len(views)}")
+        for name in sorted(views.keys()):
+            print(f"  - {name}")
+        return 0
+
+    if resource == "search":
+        if not args.target:
+            print("vn: 'show search' requires a query string", file=sys.stderr)
+            return 2
+        data = client.get("/api/search", q=args.target) or []
+        _emit_records(args, data, ("id", "path", "title"))
+        return 0
+
+    print(f"vn: unknown resource: {resource}", file=sys.stderr)
+    return 2
+
+
+def cmd_api(client: Client, args: argparse.Namespace) -> int:
+    """Generic HTTP escape hatch — any method, any path.
+
+    Mirrors `curl -u user:pass` semantics but with the auth handled by
+    the Client.  Useful for endpoints `vn show` doesn't cover, prototyping
+    new endpoints, or exercising admin routes.
+
+    Examples:
+      vn api GET  /api/admin/users
+      vn api GET  /api/tasks --query 'project=ww18&kind=ar'
+      vn api POST /api/projects --json-body '{"name":"ww19"}'
+    """
+    method = args.method.upper()
+    path = args.path
+    if not path.startswith("/"):
+        path = "/" + path
+
+    params: dict[str, Any] = {}
+    if args.query:
+        # Accept either repeated --query 'k=v' or a single 'k=v&k2=v2' string.
+        for chunk in args.query:
+            for piece in chunk.split("&"):
+                piece = piece.strip()
+                if not piece:
+                    continue
+                if "=" not in piece:
+                    print(f"vn: bad --query clause (expected key=value): {piece!r}",
+                          file=sys.stderr)
+                    return 2
+                k, v = piece.split("=", 1)
+                k = k.strip()
+                if k in params:
+                    cur = params[k]
+                    params[k] = (cur if isinstance(cur, list) else [cur]) + [v]
+                else:
+                    params[k] = v
+
+    body: Any = None
+    if args.json_body is not None:
+        try:
+            body = json.loads(args.json_body)
+        except json.JSONDecodeError as e:
+            print(f"vn: --json-body is not valid JSON: {e}", file=sys.stderr)
+            return 2
+
+    try:
+        data = client.request(method, path, params=params or None, body=body)
+    except ApiError as e:
+        # Print body to stdout (in case it's machine-readable) and the
+        # status to stderr; map HTTP class to a non-zero exit code so
+        # scripts can branch on it.
+        print(f"vn: HTTP {e.status}: {e.body or '(no body)'}", file=sys.stderr)
+        if e.status >= 500:
+            return 5
+        if e.status >= 400:
+            return 4
+        return 1
+
+    fmt = (args.format or "json").lower()
+    if fmt == "json" or args.json:
+        _print_json(data)
+    elif fmt == "jsonl":
+        if isinstance(data, list):
+            for r in data:
+                sys.stdout.write(json.dumps(r, default=str, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write(json.dumps(data, default=str, sort_keys=True) + "\n")
+    elif fmt == "raw":
+        # Pass through whatever the server sent (already decoded by Client).
+        if isinstance(data, (dict, list)):
+            _print_json(data)
+        elif data is None:
+            pass
+        else:
+            sys.stdout.write(str(data))
+            sys.stdout.write("\n")
+    else:
+        print(f"vn: --format must be json|jsonl|raw for `vn api` (got {fmt!r})",
+              file=sys.stderr)
+        return 2
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # argparse wiring
 # ---------------------------------------------------------------------------
 
@@ -491,6 +850,75 @@ def build_parser() -> argparse.ArgumentParser:
 
     pw = sub.add_parser("whoami", help="show authenticated user")
     pw.set_defaults(func=cmd_whoami)
+
+    # `vn show <resource> [target]` — read-only inspector for the rest of
+    # the API; reuses --format / --columns where it makes sense.
+    show_resources = (
+        "projects", "users", "features", "attrs", "notes", "tree",
+        "agenda", "task", "links", "me", "search",
+    )
+    ps = sub.add_parser(
+        "show",
+        help="inspect a resource (projects, users, features, attrs, notes, tree, agenda, task, links, me, search)",
+        description=(
+            "Read-only inspector for the rest of the API.\n\n"
+            "Examples:\n"
+            "  vn show projects                # list all projects\n"
+            "  vn show projects ww18           # one project's members + notes\n"
+            "  vn show users\n"
+            "  vn show features                # all feature names\n"
+            "  vn show features ic-streamlining # tasks tagged with this feature\n"
+            "  vn show attrs                   # known attribute keys + counts\n"
+            "  vn show notes                   # all notes (id, path, title)\n"
+            "  vn show notes ww18/standup.md   # one note (header + 20-line preview)\n"
+            "  vn show notes 42 --full         # full body of note id=42\n"
+            "  vn show tree                    # project -> notes hierarchy\n"
+            "  vn show agenda --owner alice\n"
+            "  vn show task T-ABC123\n"
+            "  vn show links T-ABC123\n"
+            "  vn show me                      # self info + saved views\n"
+            "  vn show search 'carveout'       # FTS across notes\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ps.add_argument("resource", choices=show_resources)
+    ps.add_argument("target", nargs="?",
+                    help="optional resource id/name (project name, feature name, note id/path, task ref, search query)")
+    ps.add_argument("--owner", help="(agenda only) filter to one owner")
+    ps.add_argument("--days", type=int, help="(agenda only) days of look-ahead")
+    ps.add_argument("--full", action="store_true",
+                    help="(notes <id|path>) dump the full markdown body instead of a 20-line preview")
+    ps.add_argument(
+        "--format", choices=("table", "json", "jsonl", "csv", "ids"),
+        help="output format (default: table; 'json' if --json is set)",
+    )
+    ps.add_argument("--columns", help="comma-separated columns for table/csv")
+    ps.set_defaults(func=cmd_show)
+
+    pa = sub.add_parser(
+        "api",
+        help="generic HTTP escape hatch — vn api METHOD /api/path [--query …] [--json-body …]",
+        description=(
+            "Call any backend endpoint by URL.  Use this for endpoints `vn show` "
+            "doesn't cover or for prototyping.\n\n"
+            "Examples:\n"
+            "  vn api GET  /api/admin/users\n"
+            "  vn api GET  /api/tasks --query 'project=ww18' --query 'kind=ar'\n"
+            "  vn api POST /api/projects --json-body '{\"name\":\"ww19\"}'\n"
+            "  vn api PATCH /api/tasks/T-ABC123 --json-body '{\"status\":\"done\"}'\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    pa.add_argument("method", choices=("GET", "POST", "PUT", "PATCH", "DELETE"),
+                    type=str.upper)
+    pa.add_argument("path", help="API path, e.g. /api/projects")
+    pa.add_argument("--query", action="append", default=[],
+                    help="repeatable key=value (or 'k=v&k2=v2')")
+    pa.add_argument("--json-body", dest="json_body",
+                    help="request body as a JSON string")
+    pa.add_argument("--format", choices=("json", "jsonl", "raw"),
+                    help="output format (default: json)")
+    pa.set_defaults(func=cmd_api)
 
     return p
 


### PR DESCRIPTION
Implements #106. Two new subcommands so operators can browse the entire VegaNotes DB from the terminal.

### `vn show <resource>`
Read-only inspector covering 11 resources: projects, users, features, attrs, notes, tree, agenda, task, links, me, search. Mirrors existing endpoints; respects `--format {table,json,jsonl,csv,ids}` and `--columns`. `vn show note <id|path> --full` dumps the body.

### `vn api METHOD /api/path`
Generic HTTP escape hatch for endpoints `vn show` doesn't cover. Supports repeatable `--query key=value`, `--json-body`, and `--format {json,jsonl,raw}`. HTTP errors print `HTTP <status>: <body>` to stderr; exit code 4 for 4xx, 5 for 5xx.

### Tests
26 new pytest cases; 93/93 pass. No backend changes.