### PR TITLE
backend: sanitize /api/search vs FTS5 operator chars (closes #110)

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -1480,12 +1480,29 @@ def admin_delete_user(
 
 @router.get("/search")
 def search(q: str, s: Session = Depends(get_session)) -> list[dict[str, Any]]:
+    # FTS5 treats characters like '-', ':', '"', '*', '^', '(' / ')' and
+    # '.' as operators; passing a raw user string (e.g. 'fit-val') would
+    # raise sqlite3.OperationalError -> 500. Convert the input into a
+    # safe AND-of-tokens query: split on whitespace, drop FTS5-special
+    # punctuation from each token, and quote each surviving token as a
+    # phrase. Empty result -> return [] without hitting the DB.
+    raw_tokens = q.split() if q else []
+    safe_tokens: list[str] = []
+    for tok in raw_tokens:
+        cleaned = _re.sub(r'[\"\*\^\(\)\:\.\-]', " ", tok).strip()
+        for piece in cleaned.split():
+            # Wrap in double quotes so SQLite treats it as a phrase token
+            # (escape any embedded quote, though we just stripped them).
+            safe_tokens.append('"' + piece.replace('"', '') + '"')
+    if not safe_tokens:
+        return []
+    fts_query = " AND ".join(safe_tokens)
     rows = s.exec(text("""
         SELECT n.id, n.path, n.title
         FROM notes_fts f JOIN note n ON n.id = f.rowid
         WHERE notes_fts MATCH :q
         LIMIT 50
-    """).bindparams(q=q)).all()
+    """).bindparams(q=fts_query)).all()
     return [{"id": r[0], "path": r[1], "title": r[2]} for r in rows]
 
 

--- a/VegaNotes/backend/tests/api/test_api.py
+++ b/VegaNotes/backend/tests/api/test_api.py
@@ -316,3 +316,19 @@ def test_patch_propagates_to_ref_rows(client):
     assert ref_body.count("#eta 2026-W20") == 2
     # Old status gone.
     assert "#status todo" not in ref_body
+
+
+def test_search_handles_fts5_special_chars(client):
+    """Regression: queries containing FTS5 operators (-, :, ", *, etc.)
+    used to bubble sqlite3.OperationalError -> 500.  They must be
+    sanitised into a phrase-AND query and return 200 (possibly empty)."""
+    for q in ["fit-val", "foo:bar", 'has"quote', "wild*", "a.b", "(paren)"]:
+        r = client.get(f"/api/search?q={q}", headers={"Authorization": AUTH})
+        assert r.status_code == 200, f"q={q!r} -> {r.status_code}: {r.text}"
+        assert isinstance(r.json(), list)
+
+
+def test_search_empty_query_returns_empty_list(client):
+    r = client.get("/api/search?q=%20%20", headers={"Authorization": AUTH})
+    assert r.status_code == 200
+    assert r.json() == []


### PR DESCRIPTION
Fixes #110. `/api/search` 500'd for any query containing an FTS5 operator char (`-`, `:`, `"`, `*`, `^`, `(`, `)`, `.`) — including the very common case `fit-val`. Now the endpoint tokenises on whitespace, strips those chars, wraps surviving tokens in double quotes, and ANDs them. Empty input returns `[]`. Two new regression tests; 63/63 backend tests pass.