### PR TITLE
feat(VegaNotes): gamification Phase 1 — activity event log

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -24,13 +24,14 @@ from ..markdown_ops import (
     find_ref_row_lines, patch_ref_rows,
 )
 from ..models import (
-    Feature, Link, Note, Project, ProjectMember, Task, TaskAttr, TaskFeature,
-    TaskOwner, TaskProject, User,
+    ActivityEvent, Feature, Link, Note, Project, ProjectMember, Task, TaskAttr,
+    TaskFeature, TaskOwner, TaskProject, User,
 )
 from ..parser import parse
 from ..safe_io import (
     StaleWriteError, _safe_write_unlocked, etag_for, etag_for_bytes, safe_write, with_file_lock,
 )
+from .. import gamify
 
 router = APIRouter(dependencies=[Depends(require_user)])
 
@@ -296,6 +297,8 @@ def upsert_note(
         raise HTTPException(403, "manager role required to write notes")
     full = settings.notes_dir / body.path
     expected = body.if_match if body.if_match is not None else if_match
+    pre_existing = full.exists()
+    pre_body = full.read_text(encoding="utf-8") if pre_existing else ""
     try:
         new_etag = safe_write(
             full, body.body_md,
@@ -314,6 +317,12 @@ def upsert_note(
             },
         )
     note = reindex_file(full, s)
+    if not pre_existing:
+        gamify.record_event(s, user, gamify.NOTE_CREATED, ref=body.path)
+    elif pre_body.strip() != body.body_md.strip():
+        # Skip whitespace-only / no-op writes so streaks aren't gamed by
+        # repeatedly saving an unchanged file.
+        gamify.record_event(s, user, gamify.NOTE_EDITED, ref=body.path)
     return {"id": note.id, "path": note.path, "etag": new_etag}
 
 
@@ -579,6 +588,11 @@ def create_task(
         reindex_file(full, s)
         created = s.exec(select(Task).where(Task.task_uuid == new_id)).first()
 
+    gamify.record_event(
+        s, user, gamify.TASK_CREATED,
+        ref=created.task_uuid or f"task#{created.id}",
+        meta={"kind": created.kind, "status": created.status},
+    )
     return _task_to_dict(s, created, include_children=True) | {"note_path": rel}
 
 
@@ -682,6 +696,11 @@ def create_ar_under_task(
     created = s.exec(select(Task).where(Task.task_uuid == new_id)).first()
     if created is None:
         raise HTTPException(500, "AR created but not found in index — please refresh")
+    gamify.record_event(
+        s, user, gamify.TASK_CREATED,
+        ref=created.task_uuid or f"task#{created.id}",
+        meta={"kind": "ar", "parent_task_uuid": parent_uuid},
+    )
     return _task_to_dict(s, created) | {"parent_task_uuid": parent_uuid}
 
 
@@ -1444,8 +1463,11 @@ def patch_task(
 
     md = note.body_md
     changed = False
+    old_status = t.status
+    status_changed = False
     if body.status is not None:
         md = update_task_status(md, t.line, body.status)
+        status_changed = (body.status != old_status)
         changed = True
     if body.priority is not None:
         md = (replace_attr(md, t.line, "priority", body.priority.strip())
@@ -1555,6 +1577,20 @@ def patch_task(
                     reindex_file(ref_full, s)
 
     refreshed = s.get(Task, task_id)
+    if status_changed and body.status is not None:
+        ev_ref = (refreshed.task_uuid if refreshed and refreshed.task_uuid
+                  else (t.task_uuid or f"task#{task_id}"))
+        gamify.record_event(
+            s, user, gamify.TASK_STATUS_SET,
+            ref=ev_ref,
+            meta={"from": old_status, "to": body.status},
+        )
+        if (body.status or "").lower() == "done":
+            gamify.record_event(
+                s, user, gamify.TASK_CLOSED,
+                ref=ev_ref,
+                meta={"from": old_status, "to": body.status},
+            )
     return _task_to_dict(s, refreshed) if refreshed else {"ok": True}
 
 
@@ -1708,6 +1744,72 @@ def replace_my_views(
     s.add(u)
     s.commit()
     return {"status": "ok", "count": len(cleaned)}
+
+
+# ---------- gamification: per-user activity log ---------------------------
+
+@router.get("/me/activity")
+def list_my_activity(
+    since: Optional[str] = Query(None, description="ISO date (YYYY-MM-DD); inclusive"),
+    until: Optional[str] = Query(None, description="ISO date (YYYY-MM-DD); exclusive"),
+    kind: Optional[str] = Query(None, description="Filter by event kind"),
+    limit: int = Query(200, ge=1, le=1000),
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    """Return the calling user's recent activity events.
+
+    Privacy: this endpoint is hard-scoped to the authenticated user. There
+    is intentionally no ``user`` query param; admins cannot view other
+    users' streams here.
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    q = select(ActivityEvent).where(ActivityEvent.user_id == u.id)
+    if since:
+        try:
+            q = q.where(ActivityEvent.ts >= datetime.fromisoformat(since))
+        except ValueError:
+            raise HTTPException(400, "since must be ISO date/datetime")
+    if until:
+        try:
+            q = q.where(ActivityEvent.ts < datetime.fromisoformat(until))
+        except ValueError:
+            raise HTTPException(400, "until must be ISO date/datetime")
+    if kind:
+        q = q.where(ActivityEvent.kind == kind)
+    q = q.order_by(ActivityEvent.ts.desc()).limit(limit)
+    rows = s.exec(q).all()
+    out: list[dict[str, Any]] = []
+    for ev in rows:
+        try:
+            meta = json.loads(ev.meta_json) if ev.meta_json else {}
+        except json.JSONDecodeError:
+            meta = {}
+        out.append({
+            "id": ev.id,
+            "kind": ev.kind,
+            "ref": ev.ref,
+            "ts": ev.ts.isoformat(),
+            "meta": meta,
+        })
+    return out
+
+
+@router.post("/admin/gamify/backfill")
+def admin_gamify_backfill(
+    s: Session = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> dict[str, Any]:
+    """One-shot reconstruction of historical events from existing tasks.
+
+    Idempotent — re-running deletes prior backfill rows first. See
+    ``app.gamify.backfill`` for the strategy.
+    """
+    counts = gamify.backfill(s)
+    s.commit()
+    return {"status": "ok", **counts}
 
 
 # ---------- admin: user management ----------------------------------------

--- a/VegaNotes/backend/app/db.py
+++ b/VegaNotes/backend/app/db.py
@@ -65,6 +65,15 @@ def init_db() -> None:
             "CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts "
             "USING fts5(title, body_md);"
         ))
+        # Composite index for the gamification activity log: per-user time
+        # range scans dominate the read pattern (`/api/me/activity`,
+        # streak/stats math). Single-column indexes on user_id and ts
+        # already exist via the model definition; this composite makes the
+        # common WHERE user_id=? AND ts>=? query a single index seek.
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_activityevent_user_ts "
+            "ON activityevent(user_id, ts);"
+        ))
         # Bidirectional view over `link` (treats every edge as undirected).
         conn.execute(text(
             "CREATE VIEW IF NOT EXISTS links_bidir AS "

--- a/VegaNotes/backend/app/gamify.py
+++ b/VegaNotes/backend/app/gamify.py
@@ -1,0 +1,129 @@
+"""Gamification event log — Phase 1 foundation.
+
+This module owns the *write side* of the gamification subsystem: a single
+``record_event`` helper that API write-handlers call after a successful
+mutation. Reads (stats, badges, streaks) live in higher phases.
+
+Design notes
+------------
+- All writes are **best-effort**: an exception inside ``record_event`` MUST
+  NOT fail the parent request. We swallow and log instead. Gamification is
+  decoration, never a correctness concern.
+- The actor is the *authenticated user*, not the task owner. "What I did"
+  semantics — closing someone else's task still counts as my close.
+- Events are append-only. There is no update path. ``vn me reset`` will
+  delete-by-user_id (Phase 4).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlmodel import Session, select
+
+from .models import ActivityEvent, User
+
+log = logging.getLogger(__name__)
+
+
+# Event kind constants. Centralised so callers + tests share spelling.
+TASK_CREATED = "task.created"
+TASK_STATUS_SET = "task.status.set"
+TASK_CLOSED = "task.closed"
+NOTE_CREATED = "note.created"
+NOTE_EDITED = "note.edited"
+
+
+def record_event(
+    s: Session,
+    user_name: str,
+    kind: str,
+    ref: str = "",
+    meta: Optional[dict[str, Any]] = None,
+    *,
+    ts: Optional[datetime] = None,
+) -> None:
+    """Append one ActivityEvent for ``user_name``. Failure is swallowed.
+
+    ``ref`` is a free-form subject identifier (task uuid, note path, …).
+    ``meta`` is JSON-encoded into ``meta_json``.
+    """
+    try:
+        u = s.exec(select(User).where(User.name == user_name)).first()
+        if u is None or u.id is None:
+            return
+        ev = ActivityEvent(
+            user_id=u.id,
+            kind=kind,
+            ref=ref or "",
+            ts=ts or datetime.utcnow(),
+            meta_json=json.dumps(meta, sort_keys=True) if meta else "",
+        )
+        s.add(ev)
+        s.flush()
+    except Exception:  # pragma: no cover - defensive
+        log.exception("record_event failed (kind=%s ref=%s)", kind, ref)
+
+
+def backfill(s: Session) -> dict[str, int]:
+    """One-shot reconstruction of historical events from existing rows.
+
+    Idempotent: removes any prior backfill rows (``meta.source == 'backfill'``)
+    before re-emitting, so re-running after data fixes is safe.
+
+    Strategy (intentionally minimal — historical actor is unknown):
+      * For every Task with at least one owner, emit ``task.created`` per
+        (task, owner) at ``task.created_at``.
+      * For every Task whose status is ``done``, additionally emit
+        ``task.closed`` per (task, owner) at ``task.updated_at``.
+      * Notes have no recorded author and are NOT backfilled.
+
+    Returns counts for observability.
+    """
+    from sqlalchemy import text as _text  # local: avoid top-level coupling
+
+    s.exec(
+        _text(
+            "DELETE FROM activityevent "
+            "WHERE meta_json LIKE '%\"source\": \"backfill\"%'"
+        )
+    )
+    from .models import Task, TaskOwner  # local to avoid circular at import
+
+    created = 0
+    closed = 0
+    rows = s.exec(
+        select(Task, TaskOwner, User)
+        .join(TaskOwner, TaskOwner.task_id == Task.id)
+        .join(User, User.id == TaskOwner.user_id)
+    ).all()
+    for t, _own, u in rows:
+        if u.id is None:
+            continue
+        meta_seed = {"source": "backfill"}
+        if t.task_uuid:
+            meta_seed["task_uuid"] = t.task_uuid
+        s.add(ActivityEvent(
+            user_id=u.id,
+            kind=TASK_CREATED,
+            ref=t.task_uuid or f"task#{t.id}",
+            ts=t.created_at,
+            meta_json=json.dumps(meta_seed, sort_keys=True),
+        ))
+        created += 1
+        if (t.status or "").lower() == "done":
+            close_meta = dict(meta_seed)
+            close_meta["from"] = ""
+            close_meta["to"] = "done"
+            s.add(ActivityEvent(
+                user_id=u.id,
+                kind=TASK_CLOSED,
+                ref=t.task_uuid or f"task#{t.id}",
+                ts=t.updated_at,
+                meta_json=json.dumps(close_meta, sort_keys=True),
+            ))
+            closed += 1
+    s.flush()
+    return {"task_created": created, "task_closed": closed}

--- a/VegaNotes/backend/app/models/__init__.py
+++ b/VegaNotes/backend/app/models/__init__.py
@@ -88,6 +88,26 @@ class Link(SQLModel, table=True):
     kind: str = "task"  # task | link | blocks | blocked_by
 
 
+class ActivityEvent(SQLModel, table=True):
+    """Append-only log of user actions for gamification stats / badges.
+
+    One row per atomic event (task close, note edit, …). The actor is the
+    authenticated user that issued the API call — not the task owner. All
+    reads are scoped to the calling user via ``/api/me/activity``; this
+    table is never exposed cross-user.
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    kind: str = Field(index=True)
+    # Free-form reference for the event subject (e.g. "T-ABC123" or note
+    # path). Indexed so we can ask "all events touching this task".
+    ref: str = Field(default="", index=True)
+    ts: datetime = Field(default_factory=datetime.utcnow, index=True)
+    # JSON blob with event-specific fields (e.g. {"from":"todo","to":"done"}).
+    # Source-of-truth for badge logic; intentionally untyped.
+    meta_json: str = ""
+
+
 class ProjectMember(SQLModel, table=True):
     """RBAC: which users can access a project (folder under notes/) and at what role.
 

--- a/VegaNotes/backend/tests/api/test_gamify.py
+++ b/VegaNotes/backend/tests/api/test_gamify.py
@@ -1,0 +1,235 @@
+"""Phase 1 gamification: activity event log.
+
+Verifies that each instrumented write endpoint emits exactly one event,
+that ``GET /api/me/activity`` is hard-scoped to the caller, and that
+``POST /api/admin/gamify/backfill`` is idempotent.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+DATA = Path(tempfile.mkdtemp(prefix="vega-gamify-"))
+os.environ["VEGANOTES_DATA_DIR"] = str(DATA)
+os.environ["VEGANOTES_SERVE_STATIC"] = "false"
+
+from app.main import app  # noqa: E402
+
+ADMIN = "Basic " + base64.b64encode(b"admin:admin").decode()
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+    shutil.rmtree(DATA, ignore_errors=True)
+
+
+def _activity(client, **params) -> list[dict]:
+    r = client.get("/api/me/activity", params=params, headers={"Authorization": ADMIN})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _kinds(events: list[dict]) -> list[str]:
+    return [e["kind"] for e in events]
+
+
+def test_note_create_emits_one_event(client):
+    before = _activity(client, kind="note.created")
+    r = client.put(
+        "/api/notes",
+        json={"path": "gamify-a.md", "body_md": "# A\n\nfirst note\n"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200, r.text
+    after = _activity(client, kind="note.created")
+    assert len(after) == len(before) + 1
+    assert after[0]["ref"] == "gamify-a.md"
+
+
+def test_note_edit_emits_event(client):
+    # baseline create
+    client.put(
+        "/api/notes",
+        json={"path": "gamify-edit.md", "body_md": "# E\n\nv1\n"},
+        headers={"Authorization": ADMIN},
+    )
+    before = _activity(client, kind="note.edited")
+    r = client.put(
+        "/api/notes",
+        json={"path": "gamify-edit.md", "body_md": "# E\n\nv2 with changes\n"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200, r.text
+    after = _activity(client, kind="note.edited")
+    assert len(after) == len(before) + 1
+
+
+def test_note_whitespace_only_change_skipped(client):
+    client.put(
+        "/api/notes",
+        json={"path": "gamify-ws.md", "body_md": "# W\n\nstable body\n"},
+        headers={"Authorization": ADMIN},
+    )
+    before = _activity(client, kind="note.edited")
+    # Pure trailing whitespace change — should NOT produce a note.edited event.
+    r = client.put(
+        "/api/notes",
+        json={"path": "gamify-ws.md", "body_md": "# W\n\nstable body\n\n\n"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200
+    after = _activity(client, kind="note.edited")
+    assert len(after) == len(before)
+
+
+def test_task_create_emits_event(client):
+    client.put(
+        "/api/notes",
+        json={"path": "gamify-tasks.md", "body_md": "# Tasks\n"},
+        headers={"Authorization": ADMIN},
+    )
+    before = _activity(client, kind="task.created")
+    r = client.post(
+        "/api/tasks",
+        json={
+            "note_path": "gamify-tasks.md",
+            "title": "ship phase 1",
+            "owners": ["admin"],
+        },
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 201, r.text
+    task_uuid = r.json().get("task_uuid")
+    after = _activity(client, kind="task.created")
+    assert len(after) == len(before) + 1
+    assert after[0]["ref"] == task_uuid
+
+
+def test_task_status_change_emits_status_set_and_close(client):
+    # Set up a task to flip.
+    client.put(
+        "/api/notes",
+        json={"path": "gamify-status.md", "body_md": "# S\n"},
+        headers={"Authorization": ADMIN},
+    )
+    r = client.post(
+        "/api/tasks",
+        json={
+            "note_path": "gamify-status.md",
+            "title": "flip me",
+            "owners": ["admin"],
+        },
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 201
+    ref = r.json()["task_uuid"]
+
+    set_before = _activity(client, kind="task.status.set")
+    closed_before = _activity(client, kind="task.closed")
+    r = client.patch(
+        f"/api/tasks/{ref}",
+        json={"status": "done"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200, r.text
+    set_after = _activity(client, kind="task.status.set")
+    closed_after = _activity(client, kind="task.closed")
+    assert len(set_after) == len(set_before) + 1
+    assert len(closed_after) == len(closed_before) + 1
+    assert set_after[0]["meta"]["from"] == "todo"
+    assert set_after[0]["meta"]["to"] == "done"
+
+
+def test_patch_no_status_change_no_event(client):
+    client.put(
+        "/api/notes",
+        json={"path": "gamify-noop.md", "body_md": "# N\n"},
+        headers={"Authorization": ADMIN},
+    )
+    r = client.post(
+        "/api/tasks",
+        json={"note_path": "gamify-noop.md", "title": "hold steady", "owners": ["admin"]},
+        headers={"Authorization": ADMIN},
+    )
+    ref = r.json()["task_uuid"]
+    before = _activity(client, kind="task.status.set")
+    # Patch a non-status field; no status event expected.
+    r = client.patch(
+        f"/api/tasks/{ref}",
+        json={"priority": "p2"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200
+    after = _activity(client, kind="task.status.set")
+    assert len(after) == len(before)
+
+
+def test_activity_filters_by_kind_since_limit(client):
+    # The above tests have already populated several events. Sanity-check
+    # that filtering / pagination works.
+    only_creates = _activity(client, kind="task.created")
+    assert all(e["kind"] == "task.created" for e in only_creates)
+    capped = _activity(client, limit=2)
+    assert len(capped) <= 2
+
+
+def test_activity_rejects_bad_date(client):
+    r = client.get(
+        "/api/me/activity",
+        params={"since": "not-a-date"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 400
+
+
+def test_admin_backfill_is_idempotent(client):
+    r1 = client.post("/api/admin/gamify/backfill", headers={"Authorization": ADMIN})
+    assert r1.status_code == 200, r1.text
+    counts1 = r1.json()
+    r2 = client.post("/api/admin/gamify/backfill", headers={"Authorization": ADMIN})
+    assert r2.status_code == 200
+    counts2 = r2.json()
+    # Same row counts both runs (deletes-and-re-inserts).
+    assert counts1["task_created"] == counts2["task_created"]
+    assert counts1["task_closed"] == counts2["task_closed"]
+    # And we backfilled at least the tasks created in this module.
+    assert counts1["task_created"] >= 3
+
+
+def test_activity_endpoint_self_only(client):
+    # /api/me/activity does not accept a `user` param — admins cannot
+    # peek at someone else's stream this way.
+    r = client.get(
+        "/api/me/activity",
+        params={"user": "someone-else"},
+        headers={"Authorization": ADMIN},
+    )
+    # The query param is silently ignored (FastAPI tolerates extras), and
+    # the response is still scoped to the caller. The privacy contract is
+    # that there's no parameter binding for cross-user reads.
+    assert r.status_code == 200
+    # Every returned event MUST have been recorded for the admin user.
+    # We can't see user_id from the public payload, but we can at least
+    # assert the endpoint doesn't fail. The hard guarantee lives in the
+    # endpoint signature itself (no `user_id` Query param).
+
+
+def test_backfill_requires_admin(client):
+    # Build a non-admin user and confirm 403.
+    r = client.post(
+        "/api/admin/users",
+        json={"name": "alice", "password": "alicepw", "is_admin": False},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code in (200, 201, 409), r.text
+    alice_auth = "Basic " + base64.b64encode(b"alice:alicepw").decode()
+    r = client.post("/api/admin/gamify/backfill", headers={"Authorization": alice_auth})
+    assert r.status_code == 403


### PR DESCRIPTION
Implements Phase 1 of the gamification plan (solo / self-progress). Foundational instrumentation only — no stats/badges/CLI surface yet (Phases 2–4).

Adds an append-only `activityevent` table, a single `record_event()` helper, hooks on the four task/note write endpoints, a hard-self-scoped `GET /api/me/activity`, and an admin-only idempotent backfill. 11 new tests; full backend suite green (163/163).

Closes #128.