### PR TITLE
feat(VegaNotes): gamification Phase 2 — personal stats + vn me CLI

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -24,13 +24,14 @@ from ..markdown_ops import (
     find_ref_row_lines, patch_ref_rows,
 )
 from ..models import (
-    Feature, Link, Note, Project, ProjectMember, Task, TaskAttr, TaskFeature,
-    TaskOwner, TaskProject, User,
+    ActivityEvent, Feature, Link, Note, Project, ProjectMember, Task, TaskAttr,
+    TaskFeature, TaskOwner, TaskProject, User,
 )
 from ..parser import parse
 from ..safe_io import (
     StaleWriteError, _safe_write_unlocked, etag_for, etag_for_bytes, safe_write, with_file_lock,
 )
+from .. import gamify
 
 router = APIRouter(dependencies=[Depends(require_user)])
 
@@ -296,6 +297,8 @@ def upsert_note(
         raise HTTPException(403, "manager role required to write notes")
     full = settings.notes_dir / body.path
     expected = body.if_match if body.if_match is not None else if_match
+    pre_existing = full.exists()
+    pre_body = full.read_text(encoding="utf-8") if pre_existing else ""
     try:
         new_etag = safe_write(
             full, body.body_md,
@@ -314,6 +317,12 @@ def upsert_note(
             },
         )
     note = reindex_file(full, s)
+    if not pre_existing:
+        gamify.record_event(s, user, gamify.NOTE_CREATED, ref=body.path)
+    elif pre_body.strip() != body.body_md.strip():
+        # Skip whitespace-only / no-op writes so streaks aren't gamed by
+        # repeatedly saving an unchanged file.
+        gamify.record_event(s, user, gamify.NOTE_EDITED, ref=body.path)
     return {"id": note.id, "path": note.path, "etag": new_etag}
 
 
@@ -579,6 +588,11 @@ def create_task(
         reindex_file(full, s)
         created = s.exec(select(Task).where(Task.task_uuid == new_id)).first()
 
+    gamify.record_event(
+        s, user, gamify.TASK_CREATED,
+        ref=created.task_uuid or f"task#{created.id}",
+        meta={"kind": created.kind, "status": created.status},
+    )
     return _task_to_dict(s, created, include_children=True) | {"note_path": rel}
 
 
@@ -682,6 +696,11 @@ def create_ar_under_task(
     created = s.exec(select(Task).where(Task.task_uuid == new_id)).first()
     if created is None:
         raise HTTPException(500, "AR created but not found in index — please refresh")
+    gamify.record_event(
+        s, user, gamify.TASK_CREATED,
+        ref=created.task_uuid or f"task#{created.id}",
+        meta={"kind": "ar", "parent_task_uuid": parent_uuid},
+    )
     return _task_to_dict(s, created) | {"parent_task_uuid": parent_uuid}
 
 
@@ -1444,8 +1463,11 @@ def patch_task(
 
     md = note.body_md
     changed = False
+    old_status = t.status
+    status_changed = False
     if body.status is not None:
         md = update_task_status(md, t.line, body.status)
+        status_changed = (body.status != old_status)
         changed = True
     if body.priority is not None:
         md = (replace_attr(md, t.line, "priority", body.priority.strip())
@@ -1555,6 +1577,20 @@ def patch_task(
                     reindex_file(ref_full, s)
 
     refreshed = s.get(Task, task_id)
+    if status_changed and body.status is not None:
+        ev_ref = (refreshed.task_uuid if refreshed and refreshed.task_uuid
+                  else (t.task_uuid or f"task#{task_id}"))
+        gamify.record_event(
+            s, user, gamify.TASK_STATUS_SET,
+            ref=ev_ref,
+            meta={"from": old_status, "to": body.status},
+        )
+        if (body.status or "").lower() == "done":
+            gamify.record_event(
+                s, user, gamify.TASK_CLOSED,
+                ref=ev_ref,
+                meta={"from": old_status, "to": body.status},
+            )
     return _task_to_dict(s, refreshed) if refreshed else {"ok": True}
 
 
@@ -1708,6 +1744,129 @@ def replace_my_views(
     s.add(u)
     s.commit()
     return {"status": "ok", "count": len(cleaned)}
+
+
+# ---------- gamification: per-user activity log ---------------------------
+
+@router.get("/me/activity")
+def list_my_activity(
+    since: Optional[str] = Query(None, description="ISO date (YYYY-MM-DD); inclusive"),
+    until: Optional[str] = Query(None, description="ISO date (YYYY-MM-DD); exclusive"),
+    kind: Optional[str] = Query(None, description="Filter by event kind"),
+    limit: int = Query(200, ge=1, le=1000),
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    """Return the calling user's recent activity events.
+
+    Privacy: this endpoint is hard-scoped to the authenticated user. There
+    is intentionally no ``user`` query param; admins cannot view other
+    users' streams here.
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    q = select(ActivityEvent).where(ActivityEvent.user_id == u.id)
+    if since:
+        try:
+            q = q.where(ActivityEvent.ts >= datetime.fromisoformat(since))
+        except ValueError:
+            raise HTTPException(400, "since must be ISO date/datetime")
+    if until:
+        try:
+            q = q.where(ActivityEvent.ts < datetime.fromisoformat(until))
+        except ValueError:
+            raise HTTPException(400, "until must be ISO date/datetime")
+    if kind:
+        q = q.where(ActivityEvent.kind == kind)
+    q = q.order_by(ActivityEvent.ts.desc()).limit(limit)
+    rows = s.exec(q).all()
+    out: list[dict[str, Any]] = []
+    for ev in rows:
+        try:
+            meta = json.loads(ev.meta_json) if ev.meta_json else {}
+        except json.JSONDecodeError:
+            meta = {}
+        out.append({
+            "id": ev.id,
+            "kind": ev.kind,
+            "ref": ev.ref,
+            "ts": ev.ts.isoformat(),
+            "meta": meta,
+        })
+    return out
+
+
+@router.post("/admin/gamify/backfill")
+def admin_gamify_backfill(
+    s: Session = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> dict[str, Any]:
+    """One-shot reconstruction of historical events from existing tasks.
+
+    Idempotent — re-running deletes prior backfill rows first. See
+    ``app.gamify.backfill`` for the strategy.
+    """
+    counts = gamify.backfill(s)
+    s.commit()
+    return {"status": "ok", **counts}
+
+
+# ---------- gamification: per-user stats (read-only) ---------------------
+
+from .. import gamify_stats as _gstats  # noqa: E402  (after admin endpoint above)
+
+
+@router.get("/me/stats")
+def my_stats(
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, Any]:
+    """Return the calling user's lifetime + windowed activity stats.
+
+    Privacy: hard-scoped to the caller; no ``user`` parameter. UTC dates
+    everywhere (per-user TZ is a future enhancement).
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    return _gstats.compute_stats(s, u.id)
+
+
+@router.get("/me/streak")
+def my_streak(
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, Any]:
+    """Compact streak summary — the same numbers ``/me/stats`` returns,
+    pulled out for callers (e.g. the CLI) that only want the headline.
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    full = _gstats.compute_stats(s, u.id)
+    return {
+        "current_streak_days": full["current_streak_days"],
+        "longest_streak_days": full["longest_streak_days"],
+        "rest_tokens_remaining": full["rest_tokens_remaining"],
+        "as_of": full["as_of"],
+    }
+
+
+@router.get("/me/history")
+def my_history(
+    days: int = Query(30, ge=1, le=365),
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    """Per-day close + note-edit counts for the trailing ``days`` window.
+
+    Powers the ANSI sparkline in ``vn me history``.
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    return _gstats.compute_history(s, u.id, days=days)
 
 
 # ---------- admin: user management ----------------------------------------

--- a/VegaNotes/backend/app/gamify_stats.py
+++ b/VegaNotes/backend/app/gamify_stats.py
@@ -1,0 +1,255 @@
+"""Gamification Phase 2: read-only personal stats.
+
+Pure-Python summarisers over the ``ActivityEvent`` log written by Phase 1.
+All times are in **UTC** (per-user TZ is a future enhancement; documented
+in the plan). All reads are caller-scoped at the endpoint layer — this
+module never reaches across users.
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from sqlalchemy import text as _text
+from sqlmodel import Session, select
+
+from .models import ActivityEvent, Note, Task, TaskAttr
+
+
+# ---- date helpers ---------------------------------------------------------
+
+def _today_utc() -> date:
+    return datetime.utcnow().date()
+
+
+def _project_for_path(rel_path: str) -> Optional[str]:
+    parts = Path(rel_path).parts
+    return parts[0] if len(parts) >= 2 else None
+
+
+# ---- pure streak computation ---------------------------------------------
+
+def compute_streak(
+    active_days: set[date],
+    today: date,
+    *,
+    rest_tokens_per_window: int = 2,
+    window_days: int = 14,
+) -> dict[str, int]:
+    """Compute current and longest streak over a set of active days.
+
+    Walks backward from ``today``: each active day extends the streak;
+    each inactive day is held in a *buffer* that is only committed as a
+    consumed rest token if a later active day actually bridges across it.
+    The streak ends when buffered + already-consumed tokens would exceed
+    ``rest_tokens_per_window`` within any trailing ``window_days`` window.
+
+    Tokens held speculatively (i.e. never bridged) do not count against
+    ``rest_tokens_remaining`` — so a long lapse beyond the streak's true
+    end doesn't punish you.
+
+    Longest streak: same algorithm pinned at every active day in turn.
+    O(n²) worst case but n is small in practice (one row per active day).
+    """
+    if not active_days:
+        return {"current": 0, "longest": 0, "rest_tokens_remaining": rest_tokens_per_window}
+
+    def _walk_back(start: date) -> tuple[int, list[date]]:
+        """Returns (streak_length, committed_token_dates)."""
+        current = 0
+        committed: list[date] = []
+        buffer: list[date] = []
+        cursor = start
+        # Hard guard against pathological inputs.
+        guard = 0
+        while guard < 366 * 5:
+            guard += 1
+            if cursor in active_days:
+                # Commit any buffered inactive days as token uses.
+                for d in buffer:
+                    committed.append(d)
+                buffer = []
+                current += 1
+            else:
+                # Drop committed tokens that have aged out of the trailing window.
+                cutoff = cursor - timedelta(days=window_days - 1)
+                committed_in_window = [d for d in committed if d >= cutoff]
+                if len(committed_in_window) + len(buffer) + 1 > rest_tokens_per_window:
+                    break
+                buffer.append(cursor)
+            cursor -= timedelta(days=1)
+        # Filter committed tokens to those still inside the trailing window
+        # *as of `start`* — that's what "remaining" means at this anchor.
+        cutoff = start - timedelta(days=window_days - 1)
+        committed_recent = [d for d in committed if d >= cutoff]
+        return current, committed_recent
+
+    current, committed_recent = _walk_back(today)
+    longest = current
+    for d in active_days:
+        if d > today:
+            continue
+        c, _ = _walk_back(d)
+        if c > longest:
+            longest = c
+
+    return {
+        "current": current,
+        "longest": longest,
+        "rest_tokens_remaining": max(0, rest_tokens_per_window - len(committed_recent)),
+    }
+
+
+# ---- compute pipeline -----------------------------------------------------
+
+def _events_for(s: Session, user_id: int, since: Optional[date] = None) -> list[ActivityEvent]:
+    q = select(ActivityEvent).where(ActivityEvent.user_id == user_id)
+    if since is not None:
+        q = q.where(ActivityEvent.ts >= datetime.combine(since, datetime.min.time()))
+    return list(s.exec(q.order_by(ActivityEvent.ts.asc())).all())
+
+
+def _task_by_uuid(s: Session, task_uuid: str) -> Optional[Task]:
+    return s.exec(select(Task).where(Task.task_uuid == task_uuid)).first()
+
+
+def _task_attr(s: Session, task_id: int, key: str) -> Optional[str]:
+    row = s.exec(
+        select(TaskAttr).where(TaskAttr.task_id == task_id, TaskAttr.key == key)
+    ).first()
+    return row.value if row else None
+
+
+def _is_on_time(close_ts: datetime, eta_value: str) -> Optional[bool]:
+    """Return True if closed on or before ``eta_value``, False if late.
+
+    Returns None when ``eta_value`` is in a format we don't yet parse
+    (e.g. ``ww18``); the caller excludes those from the rate.
+    """
+    if not eta_value:
+        return None
+    try:
+        eta_d = datetime.fromisoformat(eta_value.strip()).date()
+    except ValueError:
+        return None
+    return close_ts.date() <= eta_d
+
+
+def compute_stats(
+    s: Session,
+    user_id: int,
+    *,
+    today: Optional[date] = None,
+) -> dict[str, Any]:
+    today = today or _today_utc()
+    week_start = today - timedelta(days=6)         # last 7 calendar days incl today
+    month_start = today - timedelta(days=29)       # last 30 days incl today
+    thirty_days_ago_dt = datetime.combine(month_start, datetime.min.time())
+
+    events = _events_for(s, user_id)
+
+    closes_today = closes_week = closes_month = closes_lifetime = 0
+    notes_week = notes_month = 0
+    by_kind: dict[str, int] = defaultdict(int)
+    project_counts: dict[str, int] = defaultdict(int)
+    on_time_hits = on_time_total = 0
+    active_days: set[date] = set()
+
+    for ev in events:
+        d = ev.ts.date()
+        if ev.kind == "task.closed":
+            closes_lifetime += 1
+            if d == today:
+                closes_today += 1
+            if d >= week_start:
+                closes_week += 1
+            if d >= month_start:
+                closes_month += 1
+            active_days.add(d)
+            # Resolve the task once for kind / project / on-time math.
+            if ev.ref:
+                t = _task_by_uuid(s, ev.ref)
+                if t is not None:
+                    by_kind[(t.kind or "task")] += 1
+                    if ev.ts >= thirty_days_ago_dt:
+                        note = s.get(Note, t.note_id)
+                        if note:
+                            proj = _project_for_path(note.path)
+                            if proj:
+                                project_counts[proj] += 1
+                        eta = _task_attr(s, t.id, "eta") if t.id is not None else None
+                        verdict = _is_on_time(ev.ts, eta or "")
+                        if verdict is not None:
+                            on_time_total += 1
+                            if verdict:
+                                on_time_hits += 1
+        elif ev.kind in ("note.created", "note.edited"):
+            if d >= week_start:
+                notes_week += 1
+            if d >= month_start:
+                notes_month += 1
+            active_days.add(d)
+
+    streak = compute_streak(active_days, today)
+    favorite_project = (
+        max(project_counts.items(), key=lambda kv: kv[1])[0]
+        if project_counts else None
+    )
+    on_time_rate = (on_time_hits / on_time_total) if on_time_total else None
+
+    return {
+        "as_of": today.isoformat(),
+        "tasks_closed": {
+            "today": closes_today,
+            "week": closes_week,
+            "month": closes_month,
+            "lifetime": closes_lifetime,
+        },
+        "notes_touched": {"week": notes_week, "month": notes_month},
+        "current_streak_days": streak["current"],
+        "longest_streak_days": streak["longest"],
+        "rest_tokens_remaining": streak["rest_tokens_remaining"],
+        "on_time_eta_rate_30d": round(on_time_rate, 4) if on_time_rate is not None else None,
+        "on_time_sample_30d": on_time_total,
+        "favorite_project_30d": favorite_project,
+        "by_kind": dict(by_kind),
+    }
+
+
+def compute_history(
+    s: Session,
+    user_id: int,
+    *,
+    days: int = 30,
+    today: Optional[date] = None,
+) -> list[dict[str, Any]]:
+    today = today or _today_utc()
+    start = today - timedelta(days=days - 1)
+    start_dt = datetime.combine(start, datetime.min.time())
+
+    closes: dict[date, int] = defaultdict(int)
+    edits: dict[date, int] = defaultdict(int)
+    rows = s.exec(
+        select(ActivityEvent)
+        .where(ActivityEvent.user_id == user_id)
+        .where(ActivityEvent.ts >= start_dt)
+    ).all()
+    for ev in rows:
+        d = ev.ts.date()
+        if ev.kind == "task.closed":
+            closes[d] += 1
+        elif ev.kind in ("note.created", "note.edited"):
+            edits[d] += 1
+
+    out: list[dict[str, Any]] = []
+    for i in range(days):
+        d = start + timedelta(days=i)
+        out.append({
+            "date": d.isoformat(),
+            "closes": closes.get(d, 0),
+            "edits": edits.get(d, 0),
+        })
+    return out

--- a/VegaNotes/backend/tests/api/test_gamify_stats.py
+++ b/VegaNotes/backend/tests/api/test_gamify_stats.py
@@ -1,0 +1,213 @@
+"""Phase 2 gamification: personal stats endpoints + pure compute_streak.
+
+Strategy: drive the backend through its real HTTP surface (so we test the
+hooks + stats math together), then directly unit-test ``compute_streak``
+for edge cases that are awkward to reach via the API.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import shutil
+import tempfile
+from datetime import date, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+DATA = Path(tempfile.mkdtemp(prefix="vega-stats-"))
+os.environ["VEGANOTES_DATA_DIR"] = str(DATA)
+os.environ["VEGANOTES_SERVE_STATIC"] = "false"
+
+from app.main import app  # noqa: E402
+from app.gamify_stats import compute_streak  # noqa: E402
+
+ADMIN = "Basic " + base64.b64encode(b"admin:admin").decode()
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+    shutil.rmtree(DATA, ignore_errors=True)
+
+
+def _create_task(client, note_path: str, title: str, **extra) -> str:
+    client.put(
+        "/api/notes",
+        json={"path": note_path, "body_md": "# t\n"},
+        headers={"Authorization": ADMIN},
+    )
+    body = {"note_path": note_path, "title": title, "owners": ["admin"]}
+    body.update(extra)
+    r = client.post("/api/tasks", json=body, headers={"Authorization": ADMIN})
+    assert r.status_code == 201, r.text
+    return r.json()["task_uuid"]
+
+
+def _close(client, ref: str):
+    r = client.patch(
+        f"/api/tasks/{ref}",
+        json={"status": "done"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Endpoint smoke tests
+# ---------------------------------------------------------------------------
+
+def test_stats_endpoint_basic_shape(client):
+    r = client.get("/api/me/stats", headers={"Authorization": ADMIN})
+    assert r.status_code == 200, r.text
+    data = r.json()
+    for key in (
+        "as_of", "tasks_closed", "notes_touched",
+        "current_streak_days", "longest_streak_days", "rest_tokens_remaining",
+        "on_time_eta_rate_30d", "on_time_sample_30d", "favorite_project_30d",
+        "by_kind",
+    ):
+        assert key in data
+    for k in ("today", "week", "month", "lifetime"):
+        assert k in data["tasks_closed"]
+
+
+def test_close_increments_today_and_lifetime(client):
+    before = client.get("/api/me/stats", headers={"Authorization": ADMIN}).json()
+    ref = _create_task(client, "stats-incr.md", "incr me")
+    _close(client, ref)
+    after = client.get("/api/me/stats", headers={"Authorization": ADMIN}).json()
+    assert after["tasks_closed"]["today"] == before["tasks_closed"]["today"] + 1
+    assert after["tasks_closed"]["lifetime"] == before["tasks_closed"]["lifetime"] + 1
+    assert after["current_streak_days"] >= 1
+    assert after["by_kind"].get("task", 0) >= 1
+
+
+def test_streak_endpoint_compact_shape(client):
+    r = client.get("/api/me/streak", headers={"Authorization": ADMIN})
+    assert r.status_code == 200
+    keys = set(r.json().keys())
+    assert keys == {
+        "current_streak_days", "longest_streak_days",
+        "rest_tokens_remaining", "as_of",
+    }
+
+
+def test_history_default_30_days(client):
+    r = client.get("/api/me/history", headers={"Authorization": ADMIN})
+    assert r.status_code == 200
+    rows = r.json()
+    assert len(rows) == 30
+    for row in rows:
+        assert set(row.keys()) == {"date", "closes", "edits"}
+
+
+def test_history_custom_window(client):
+    r = client.get("/api/me/history?days=7", headers={"Authorization": ADMIN})
+    assert r.status_code == 200
+    assert len(r.json()) == 7
+
+
+def test_history_rejects_out_of_range(client):
+    r = client.get("/api/me/history?days=0", headers={"Authorization": ADMIN})
+    assert r.status_code == 422
+    r = client.get("/api/me/history?days=400", headers={"Authorization": ADMIN})
+    assert r.status_code == 422
+
+
+def test_on_time_rate_when_eta_is_iso_date(client):
+    """Closing a task before its ETA bumps the on-time hit count."""
+    today_iso = date.today().isoformat()
+    _create_task(client, "stats-ontime.md", "ahead of time", eta=today_iso)
+    # The fresh stats call should now have at least one on-time sample.
+    data = client.get("/api/me/stats", headers={"Authorization": ADMIN}).json()
+    # Find the task_uuid we just made by walking activity.
+    acts = client.get(
+        "/api/me/activity?kind=task.created&limit=5",
+        headers={"Authorization": ADMIN},
+    ).json()
+    ref = acts[0]["ref"]
+    _close(client, ref)
+    after = client.get("/api/me/stats", headers={"Authorization": ADMIN}).json()
+    assert after["on_time_sample_30d"] >= 1
+    # We closed today, eta is today → on time.
+    assert after["on_time_eta_rate_30d"] is not None
+
+
+def test_favorite_project_30d_picks_top_folder(client):
+    # Create+close two tasks under a single project folder.
+    _create_task(client, "famproj/notes.md", "p-task-1")
+    acts = client.get(
+        "/api/me/activity?kind=task.created&limit=5",
+        headers={"Authorization": ADMIN},
+    ).json()
+    _close(client, acts[0]["ref"])
+    _create_task(client, "famproj/notes.md", "p-task-2")
+    acts = client.get(
+        "/api/me/activity?kind=task.created&limit=5",
+        headers={"Authorization": ADMIN},
+    ).json()
+    _close(client, acts[0]["ref"])
+
+    data = client.get("/api/me/stats", headers={"Authorization": ADMIN}).json()
+    # famproj should be a candidate; other tests close root-level tasks
+    # which produce no project attribution.
+    assert data["favorite_project_30d"] == "famproj"
+
+
+# ---------------------------------------------------------------------------
+# Pure compute_streak unit tests
+# ---------------------------------------------------------------------------
+
+def _d(s: str) -> date:
+    return datetime.strptime(s, "%Y-%m-%d").date()
+
+
+def test_streak_zero_when_no_activity():
+    out = compute_streak(set(), _d("2026-04-27"))
+    assert out["current"] == 0 and out["longest"] == 0
+    assert out["rest_tokens_remaining"] == 2
+
+
+def test_streak_consecutive_days():
+    days = {_d("2026-04-25"), _d("2026-04-26"), _d("2026-04-27")}
+    out = compute_streak(days, _d("2026-04-27"))
+    assert out["current"] == 3
+    assert out["longest"] == 3
+
+
+def test_streak_uses_one_rest_token_for_a_gap():
+    # Active: today, two days ago. One inactive day yesterday burns a token.
+    days = {_d("2026-04-25"), _d("2026-04-27")}
+    out = compute_streak(days, _d("2026-04-27"))
+    assert out["current"] == 2
+    assert out["rest_tokens_remaining"] == 1
+
+
+def test_streak_breaks_after_three_inactive_days_in_window():
+    # Active: today, then 4 days ago. Three inactive days = exhausts both
+    # tokens and one more → break.
+    days = {_d("2026-04-23"), _d("2026-04-27")}
+    out = compute_streak(days, _d("2026-04-27"))
+    assert out["current"] == 1  # only today survives
+
+
+def test_streak_includes_today_inactive_with_token_burn():
+    # Today inactive but yesterday active → still on a streak (tokens cover today).
+    days = {_d("2026-04-26")}
+    out = compute_streak(days, _d("2026-04-27"))
+    assert out["current"] == 1
+    assert out["rest_tokens_remaining"] == 1
+
+
+def test_longest_streak_separate_from_current():
+    # An old long streak that has since lapsed still shows up as longest.
+    days = (
+        {_d("2026-01-01") + timedelta(days=i) for i in range(10)}  # 10-day run
+        | {_d("2026-04-27")}                                        # today
+    )
+    out = compute_streak(days, _d("2026-04-27"))
+    assert out["longest"] >= 10
+    assert out["current"] == 1

--- a/VegaNotes/tools/vn/README.md
+++ b/VegaNotes/tools/vn/README.md
@@ -233,6 +233,33 @@ The slug uses the same lowercase-kebab rule as the rest of VegaNotes
 
 Prints the authenticated user (and `(admin)` if applicable).
 
+### `vn me <subcommand>` — personal stats (gamification)
+
+Solo / self-progress mode: every stat is private to you. Reads only;
+nothing here changes data.
+
+```bash
+vn me stats                  # full stats card
+vn me streak                 # current + longest streak (with rest tokens)
+vn me history --days 30      # ANSI sparkline of closes/edits per day
+vn me activity               # recent event log
+vn me activity --kind task.closed --limit 20
+vn me activity --since 2026-04-01 --until 2026-04-15
+```
+
+`vn me stats` shows tasks closed (today / 7d / 30d / lifetime), notes
+touched (7d / 30d), current and longest streak, on-time-ETA rate over
+the last 30 days, your favorite project, and a per-kind breakdown.
+Streaks are forgiving: you have **2 rest tokens per rolling 14-day
+window**, so a single off day doesn't kill a long run. Dates are UTC.
+
+Pass the global `--json` flag (before `me`) to get raw JSON for any
+subcommand:
+
+```bash
+vn --json me stats | jq .current_streak_days
+```
+
 ### `vn show <resource>` — read-only inspector
 
 Browse the database without curl-ing the API by hand. Every resource maps

--- a/VegaNotes/tools/vn/tests/test_cli.py
+++ b/VegaNotes/tools/vn/tests/test_cli.py
@@ -874,3 +874,110 @@ def test_list_mixed_columns_returns_2(fake_client, capsys):
     rc = cli.main(["list", "--columns", "id,+kind"])
     assert rc == 2
     assert "cannot mix" in capsys.readouterr().err
+
+
+# ---------- vn me <subcommand> ---------------------------------------------
+
+_FAKE_STATS = {
+    "as_of": "2026-04-27",
+    "tasks_closed": {"today": 3, "week": 11, "month": 28, "lifetime": 142},
+    "notes_touched": {"week": 6, "month": 19},
+    "current_streak_days": 7,
+    "longest_streak_days": 23,
+    "rest_tokens_remaining": 1,
+    "on_time_eta_rate_30d": 0.81,
+    "on_time_sample_30d": 26,
+    "favorite_project_30d": "ww18",
+    "by_kind": {"task": 26, "ar": 2},
+}
+
+
+def test_me_stats_renders_card(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/stats")] = _FAKE_STATS
+    rc = cli.main(["me", "stats"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "as of 2026-04-27" in out
+    assert "closed today      3" in out
+    assert "current streak    7 day(s)" in out
+    assert "favorite project  ww18" in out
+    assert "on-time ETA (30d) 81%" in out
+
+
+def test_me_stats_json_passthrough(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/stats")] = _FAKE_STATS
+    rc = cli.main(["--json", "me", "stats"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["current_streak_days"] == 7
+
+
+def test_me_streak_compact(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/streak")] = {
+        "current_streak_days": 5, "longest_streak_days": 11,
+        "rest_tokens_remaining": 2, "as_of": "2026-04-27",
+    }
+    rc = cli.main(["me", "streak"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "5 day(s)" in out
+    assert "longest: 11" in out
+    assert "rest tokens: 2" in out
+
+
+def test_me_streak_zero_no_flame(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/streak")] = {
+        "current_streak_days": 0, "longest_streak_days": 4,
+        "rest_tokens_remaining": 2, "as_of": "2026-04-27",
+    }
+    cli.main(["me", "streak"])
+    out = capsys.readouterr().out
+    # No flame when current == 0
+    assert "🔥" not in out
+
+
+def test_me_history_sparkline(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/history")] = [
+        {"date": "2026-04-21", "closes": 0, "edits": 1},
+        {"date": "2026-04-22", "closes": 2, "edits": 3},
+        {"date": "2026-04-23", "closes": 1, "edits": 0},
+    ]
+    rc = cli.main(["me", "history", "--days", "3"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "closes" in out and "edits" in out
+    assert "total 3" in out  # 0+2+1
+    assert "total 4" in out  # 1+3+0
+    # The history endpoint was called with the requested days param.
+    call = [c for c in fake_client.calls if c[1] == "/api/me/history"][0]
+    assert call[2] == {"days": 3}
+
+
+def test_me_history_empty(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/history")] = []
+    cli.main(["me", "history"])
+    assert "no activity" in capsys.readouterr().out
+
+
+def test_me_activity_filters(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/activity")] = [
+        {"id": 1, "kind": "task.closed", "ref": "T-X", "ts": "2026-04-27T10:00:00",
+         "meta": {"from": "todo", "to": "done"}},
+    ]
+    rc = cli.main(["me", "activity", "--kind", "task.closed", "--limit", "5"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "task.closed" in out and "T-X" in out
+    call = [c for c in fake_client.calls if c[1] == "/api/me/activity"][0]
+    assert call[2] == {"kind": "task.closed", "limit": 5}
+
+
+def test_me_activity_empty(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/activity")] = []
+    cli.main(["me", "activity"])
+    assert "no events" in capsys.readouterr().out
+
+
+def test_me_subcommand_required(fake_client, capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["me"])

--- a/VegaNotes/tools/vn/vn/cli.py
+++ b/VegaNotes/tools/vn/vn/cli.py
@@ -444,6 +444,114 @@ def cmd_whoami(client: Client, args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# `vn me <subcommand>` — gamification surface (Phase 2: stats/streak/history)
+# ---------------------------------------------------------------------------
+#
+# Every endpoint under /api/me/... is hard-scoped to the authenticated user
+# server-side. The CLI just renders.
+
+_SPARK_BARS = "▁▂▃▄▅▆▇█"
+
+
+def _sparkline(values: list[int]) -> str:
+    if not values:
+        return ""
+    peak = max(values)
+    if peak == 0:
+        return _SPARK_BARS[0] * len(values)
+    return "".join(
+        _SPARK_BARS[min(len(_SPARK_BARS) - 1, (v * (len(_SPARK_BARS) - 1)) // peak)]
+        for v in values
+    )
+
+
+def cmd_me_stats(client: Client, args: argparse.Namespace) -> int:
+    data = client.get("/api/me/stats")
+    if args.json:
+        _print_json(data)
+        return 0
+    tc = data.get("tasks_closed", {})
+    nt = data.get("notes_touched", {})
+    rate = data.get("on_time_eta_rate_30d")
+    rate_str = f"{rate * 100:.0f}% (n={data.get('on_time_sample_30d', 0)})" if rate is not None else "—"
+    print(f"as of {data.get('as_of', '?')} (UTC)")
+    print()
+    print(f"  closed today      {tc.get('today', 0)}")
+    print(f"  closed last 7d    {tc.get('week', 0)}")
+    print(f"  closed last 30d   {tc.get('month', 0)}")
+    print(f"  closed lifetime   {tc.get('lifetime', 0)}")
+    print()
+    print(f"  notes touched 7d  {nt.get('week', 0)}")
+    print(f"  notes touched 30d {nt.get('month', 0)}")
+    print()
+    print(f"  current streak    {data.get('current_streak_days', 0)} day(s) "
+          f"[rest tokens: {data.get('rest_tokens_remaining', 0)}]")
+    print(f"  longest streak    {data.get('longest_streak_days', 0)} day(s)")
+    print(f"  on-time ETA (30d) {rate_str}")
+    fav = data.get("favorite_project_30d") or "—"
+    print(f"  favorite project  {fav}")
+    by_kind = data.get("by_kind") or {}
+    if by_kind:
+        parts = ", ".join(f"{k}: {v}" for k, v in sorted(by_kind.items()))
+        print(f"  by kind           {parts}")
+    return 0
+
+
+def cmd_me_streak(client: Client, args: argparse.Namespace) -> int:
+    data = client.get("/api/me/streak")
+    if args.json:
+        _print_json(data)
+        return 0
+    cur = data.get("current_streak_days", 0)
+    longest = data.get("longest_streak_days", 0)
+    tokens = data.get("rest_tokens_remaining", 0)
+    flame = "🔥" if cur > 0 else "·"
+    print(f"{flame} {cur} day(s)  (longest: {longest}, rest tokens: {tokens})")
+    return 0
+
+
+def cmd_me_history(client: Client, args: argparse.Namespace) -> int:
+    days = max(1, min(365, getattr(args, "days", 30) or 30))
+    data = client.get("/api/me/history", days=days)
+    if args.json:
+        _print_json(data)
+        return 0
+    closes = [int(d.get("closes", 0)) for d in data]
+    edits = [int(d.get("edits", 0)) for d in data]
+    if not closes:
+        print("(no activity)")
+        return 0
+    print(f"closes  {_sparkline(closes)}  total {sum(closes)}")
+    print(f"edits   {_sparkline(edits)}  total {sum(edits)}")
+    print(f"        {data[0]['date']} … {data[-1]['date']}  ({len(data)}d)")
+    return 0
+
+
+def cmd_me_activity(client: Client, args: argparse.Namespace) -> int:
+    params: dict[str, Any] = {}
+    if getattr(args, "since", None):
+        params["since"] = args.since
+    if getattr(args, "until", None):
+        params["until"] = args.until
+    if getattr(args, "kind", None):
+        params["kind"] = args.kind
+    if getattr(args, "limit", None):
+        params["limit"] = args.limit
+    data = client.get("/api/me/activity", **params)
+    if args.json:
+        _print_json(data)
+        return 0
+    if not data:
+        print("(no events)")
+        return 0
+    for ev in data:
+        meta = ev.get("meta") or {}
+        meta_str = " " + json.dumps(meta, sort_keys=True) if meta else ""
+        print(f"{ev.get('ts', '')}  {ev.get('kind', ''):<18}  {ev.get('ref', '')}{meta_str}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # `vn show <resource>` — read-only inspector for the rest of the API.
 # ---------------------------------------------------------------------------
 #
@@ -912,6 +1020,41 @@ def build_parser() -> argparse.ArgumentParser:
 
     pw = sub.add_parser("whoami", help="show authenticated user")
     pw.set_defaults(func=cmd_whoami)
+
+    # `vn me <subcommand>` — gamification surface (Phase 2: read-only).
+    pme = sub.add_parser(
+        "me",
+        help="personal stats / streak / activity (gamification)",
+        description=(
+            "Solo / self-progress mode: stats are visible only to you.\n\n"
+            "Examples:\n"
+            "  vn me stats                  # full stats card\n"
+            "  vn me streak                 # current + longest streak\n"
+            "  vn me history --days 30      # ANSI sparkline of closes/edits\n"
+            "  vn me activity --kind task.closed --limit 20\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    me_sub = pme.add_subparsers(dest="me_command", required=True)
+
+    pms = me_sub.add_parser("stats", help="full personal stats card")
+    pms.set_defaults(func=cmd_me_stats)
+
+    pmr = me_sub.add_parser("streak", help="current + longest streak")
+    pmr.set_defaults(func=cmd_me_streak)
+
+    pmh = me_sub.add_parser("history", help="per-day close/edit sparkline")
+    pmh.add_argument("--days", type=int, default=30,
+                     help="trailing window in days (1..365, default 30)")
+    pmh.set_defaults(func=cmd_me_history)
+
+    pma = me_sub.add_parser("activity", help="recent activity event log")
+    pma.add_argument("--since", help="ISO date (YYYY-MM-DD); inclusive")
+    pma.add_argument("--until", help="ISO date (YYYY-MM-DD); exclusive")
+    pma.add_argument("--kind", help="filter by event kind (e.g. task.closed)")
+    pma.add_argument("--limit", type=int, default=50,
+                     help="cap on rows returned (1..1000, default 50)")
+    pma.set_defaults(func=cmd_me_activity)
 
     # `vn show <resource> [target]` — read-only inspector for the rest of
     # the API; reuses --format / --columns where it makes sense.


### PR DESCRIPTION
Phase 2 of the gamification plan, **stacked on PR #129**.

Adds the read-only stats surface: `GET /api/me/{stats,streak,history}` plus a new `vn me` CLI subcommand group (stats / streak / history / activity, with an 8-level ANSI sparkline). All endpoints are hard-scoped to the calling user (no cross-user param). Streak math allows 2 rest tokens per rolling 14-day window and only commits a token when a later active day actually bridges it.

23 new tests (14 backend + 9 CLI). All suites green.

Closes #130. Base branch is `feat/gamify-event-log`; merge #129 first.