### PR TITLE
feat(VegaNotes): gamification Phase 3 — badges + per-user TZ

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -24,13 +24,14 @@ from ..markdown_ops import (
     find_ref_row_lines, patch_ref_rows,
 )
 from ..models import (
-    Feature, Link, Note, Project, ProjectMember, Task, TaskAttr, TaskFeature,
-    TaskOwner, TaskProject, User,
+    ActivityEvent, Feature, Link, Note, Project, ProjectMember, Task, TaskAttr,
+    TaskFeature, TaskOwner, TaskProject, User,
 )
 from ..parser import parse
 from ..safe_io import (
     StaleWriteError, _safe_write_unlocked, etag_for, etag_for_bytes, safe_write, with_file_lock,
 )
+from .. import gamify
 
 router = APIRouter(dependencies=[Depends(require_user)])
 
@@ -296,6 +297,8 @@ def upsert_note(
         raise HTTPException(403, "manager role required to write notes")
     full = settings.notes_dir / body.path
     expected = body.if_match if body.if_match is not None else if_match
+    pre_existing = full.exists()
+    pre_body = full.read_text(encoding="utf-8") if pre_existing else ""
     try:
         new_etag = safe_write(
             full, body.body_md,
@@ -314,6 +317,12 @@ def upsert_note(
             },
         )
     note = reindex_file(full, s)
+    if not pre_existing:
+        gamify.record_event(s, user, gamify.NOTE_CREATED, ref=body.path)
+    elif pre_body.strip() != body.body_md.strip():
+        # Skip whitespace-only / no-op writes so streaks aren't gamed by
+        # repeatedly saving an unchanged file.
+        gamify.record_event(s, user, gamify.NOTE_EDITED, ref=body.path)
     return {"id": note.id, "path": note.path, "etag": new_etag}
 
 
@@ -579,6 +588,11 @@ def create_task(
         reindex_file(full, s)
         created = s.exec(select(Task).where(Task.task_uuid == new_id)).first()
 
+    gamify.record_event(
+        s, user, gamify.TASK_CREATED,
+        ref=created.task_uuid or f"task#{created.id}",
+        meta={"kind": created.kind, "status": created.status},
+    )
     return _task_to_dict(s, created, include_children=True) | {"note_path": rel}
 
 
@@ -682,6 +696,11 @@ def create_ar_under_task(
     created = s.exec(select(Task).where(Task.task_uuid == new_id)).first()
     if created is None:
         raise HTTPException(500, "AR created but not found in index — please refresh")
+    gamify.record_event(
+        s, user, gamify.TASK_CREATED,
+        ref=created.task_uuid or f"task#{created.id}",
+        meta={"kind": "ar", "parent_task_uuid": parent_uuid},
+    )
     return _task_to_dict(s, created) | {"parent_task_uuid": parent_uuid}
 
 
@@ -1444,8 +1463,11 @@ def patch_task(
 
     md = note.body_md
     changed = False
+    old_status = t.status
+    status_changed = False
     if body.status is not None:
         md = update_task_status(md, t.line, body.status)
+        status_changed = (body.status != old_status)
         changed = True
     if body.priority is not None:
         md = (replace_attr(md, t.line, "priority", body.priority.strip())
@@ -1555,6 +1577,20 @@ def patch_task(
                     reindex_file(ref_full, s)
 
     refreshed = s.get(Task, task_id)
+    if status_changed and body.status is not None:
+        ev_ref = (refreshed.task_uuid if refreshed and refreshed.task_uuid
+                  else (t.task_uuid or f"task#{task_id}"))
+        gamify.record_event(
+            s, user, gamify.TASK_STATUS_SET,
+            ref=ev_ref,
+            meta={"from": old_status, "to": body.status},
+        )
+        if (body.status or "").lower() == "done":
+            gamify.record_event(
+                s, user, gamify.TASK_CLOSED,
+                ref=ev_ref,
+                meta={"from": old_status, "to": body.status},
+            )
     return _task_to_dict(s, refreshed) if refreshed else {"ok": True}
 
 
@@ -1625,7 +1661,42 @@ def whoami(
     user: str = Depends(require_user),
 ) -> dict[str, Any]:
     u = s.exec(select(User).where(User.name == user)).first()
-    return {"name": user, "is_admin": bool(u and u.is_admin)}
+    return {
+        "name": user,
+        "is_admin": bool(u and u.is_admin),
+        "tz": (u.tz if u else "") or "UTC",
+    }
+
+
+class SetTzIn(BaseModel):
+    tz: str
+
+
+@router.patch("/me/tz")
+def set_my_tz(
+    body: SetTzIn,
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, str]:
+    """Set this user's IANA timezone (e.g. 'America/Los_Angeles').
+
+    Used by gamification stats so streaks roll over at local midnight.
+    Empty string ≡ UTC. Unknown zones are rejected.
+    """
+    name = (body.tz or "").strip()
+    if name:
+        try:
+            from zoneinfo import ZoneInfo
+            ZoneInfo(name)
+        except Exception:
+            raise HTTPException(400, f"unknown timezone: {name!r}")
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None:
+        raise HTTPException(404, "user not found")
+    u.tz = name
+    s.add(u)
+    s.commit()
+    return {"status": "ok", "tz": name or "UTC"}
 
 
 class ChangePasswordIn(BaseModel):
@@ -1708,6 +1779,147 @@ def replace_my_views(
     s.add(u)
     s.commit()
     return {"status": "ok", "count": len(cleaned)}
+
+
+# ---------- gamification: per-user activity log ---------------------------
+
+@router.get("/me/activity")
+def list_my_activity(
+    since: Optional[str] = Query(None, description="ISO date (YYYY-MM-DD); inclusive"),
+    until: Optional[str] = Query(None, description="ISO date (YYYY-MM-DD); exclusive"),
+    kind: Optional[str] = Query(None, description="Filter by event kind"),
+    limit: int = Query(200, ge=1, le=1000),
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    """Return the calling user's recent activity events.
+
+    Privacy: this endpoint is hard-scoped to the authenticated user. There
+    is intentionally no ``user`` query param; admins cannot view other
+    users' streams here.
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    q = select(ActivityEvent).where(ActivityEvent.user_id == u.id)
+    if since:
+        try:
+            q = q.where(ActivityEvent.ts >= datetime.fromisoformat(since))
+        except ValueError:
+            raise HTTPException(400, "since must be ISO date/datetime")
+    if until:
+        try:
+            q = q.where(ActivityEvent.ts < datetime.fromisoformat(until))
+        except ValueError:
+            raise HTTPException(400, "until must be ISO date/datetime")
+    if kind:
+        q = q.where(ActivityEvent.kind == kind)
+    q = q.order_by(ActivityEvent.ts.desc()).limit(limit)
+    rows = s.exec(q).all()
+    out: list[dict[str, Any]] = []
+    for ev in rows:
+        try:
+            meta = json.loads(ev.meta_json) if ev.meta_json else {}
+        except json.JSONDecodeError:
+            meta = {}
+        out.append({
+            "id": ev.id,
+            "kind": ev.kind,
+            "ref": ev.ref,
+            "ts": ev.ts.isoformat(),
+            "meta": meta,
+        })
+    return out
+
+
+@router.post("/admin/gamify/backfill")
+def admin_gamify_backfill(
+    s: Session = Depends(get_session),
+    _: str = Depends(require_admin),
+) -> dict[str, Any]:
+    """One-shot reconstruction of historical events from existing tasks.
+
+    Idempotent — re-running deletes prior backfill rows first. See
+    ``app.gamify.backfill`` for the strategy.
+    """
+    counts = gamify.backfill(s)
+    s.commit()
+    return {"status": "ok", **counts}
+
+
+# ---------- gamification: per-user stats (read-only) ---------------------
+
+from .. import gamify_stats as _gstats  # noqa: E402  (after admin endpoint above)
+
+
+@router.get("/me/stats")
+def my_stats(
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, Any]:
+    """Return the calling user's lifetime + windowed activity stats.
+
+    Privacy: hard-scoped to the caller; no ``user`` parameter. UTC dates
+    everywhere (per-user TZ is a future enhancement).
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    return _gstats.compute_stats(s, u.id)
+
+
+@router.get("/me/streak")
+def my_streak(
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, Any]:
+    """Compact streak summary — the same numbers ``/me/stats`` returns,
+    pulled out for callers (e.g. the CLI) that only want the headline.
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    full = _gstats.compute_stats(s, u.id)
+    return {
+        "current_streak_days": full["current_streak_days"],
+        "longest_streak_days": full["longest_streak_days"],
+        "rest_tokens_remaining": full["rest_tokens_remaining"],
+        "as_of": full["as_of"],
+    }
+
+
+@router.get("/me/history")
+def my_history(
+    days: int = Query(30, ge=1, le=365),
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> list[dict[str, Any]]:
+    """Per-day close + note-edit counts for the trailing ``days`` window.
+
+    Powers the ANSI sparkline in ``vn me history``.
+    """
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    return _gstats.compute_history(s, u.id, days=days)
+
+
+@router.get("/me/badges")
+def my_badges(
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, Any]:
+    """Earned + locked badges for the calling user.
+
+    Hidden badges are surfaced only after they're earned; until then
+    they're rolled into ``hidden_locked_count`` so users can see *that*
+    there's more without spoiling the catalog.
+    """
+    from .. import badges as _badges
+    u = s.exec(select(User).where(User.name == user)).first()
+    if u is None or u.id is None:
+        raise HTTPException(404, "user not found")
+    return _badges.list_badges(s, u.id)
 
 
 # ---------- admin: user management ----------------------------------------

--- a/VegaNotes/backend/app/badges.py
+++ b/VegaNotes/backend/app/badges.py
@@ -1,0 +1,392 @@
+"""Gamification Phase 3: badge catalog + award engine.
+
+Each badge is a pure-function predicate over a pre-computed
+``BadgeContext`` (the calling user's activity event log + memoised task
+lookups). The catalog is small and curated — code changes ship new
+badges, not user input.
+
+``recompute_badges(s, user_id)`` is called after every ``record_event``
+write. It scans the user's events once and inserts any newly earned
+badges (idempotent via the ``ix_userbadge_user_key`` UNIQUE index).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Any, Callable, Optional
+
+from sqlmodel import Session, select
+
+from .gamify_stats import (
+    _is_on_time, _project_for_path, _task_attr, _user_tz_name,
+    compute_streak, event_local_date, resolve_tz,
+)
+from .models import ActivityEvent, Note, Task, UserBadge
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Context
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BadgeContext:
+    s: Session
+    user_id: int
+    tz_name: str
+    today: date
+    events: list[ActivityEvent]
+    closes: list[ActivityEvent]
+    note_creates: list[ActivityEvent]
+    note_edits: list[ActivityEvent]
+    status_sets: list[ActivityEvent]
+    closes_by_day: dict[date, int]
+    creates_by_day: dict[date, int]
+    edits_by_note: dict[str, int]
+    edits_by_day_per_note: dict[tuple[date, str], int]
+    active_days: set[date]
+    _task_cache: dict[str, Optional[Task]] = field(default_factory=dict)
+
+    def task(self, ref: str) -> Optional[Task]:
+        if not ref:
+            return None
+        if ref not in self._task_cache:
+            self._task_cache[ref] = self.s.exec(
+                select(Task).where(Task.task_uuid == ref)
+            ).first()
+        return self._task_cache[ref]
+
+    def project_for(self, ref: str) -> Optional[str]:
+        t = self.task(ref)
+        if t is None:
+            return None
+        n = self.s.get(Note, t.note_id)
+        return _project_for_path(n.path) if n else None
+
+    def task_age_days(self, ev: ActivityEvent) -> Optional[int]:
+        t = self.task(ev.ref)
+        if t is None:
+            return None
+        return (ev.ts - t.created_at).days
+
+    def close_was_on_time(self, ev: ActivityEvent) -> Optional[bool]:
+        t = self.task(ev.ref)
+        if t is None or t.id is None:
+            return None
+        eta = _task_attr(self.s, t.id, "eta")
+        if not eta:
+            return None
+        local_d = event_local_date(ev.ts, self.tz_name)
+        return _is_on_time(local_d, eta)
+
+
+def _build_context(s: Session, user_id: int) -> BadgeContext:
+    tz_name = _user_tz_name(s, user_id)
+    today = datetime.now(tz=timezone.utc).astimezone(resolve_tz(tz_name)).date()
+    events = list(s.exec(
+        select(ActivityEvent)
+        .where(ActivityEvent.user_id == user_id)
+        .order_by(ActivityEvent.ts.asc())
+    ).all())
+
+    closes = [e for e in events if e.kind == "task.closed"]
+    creates = [e for e in events if e.kind == "note.created"]
+    edits = [e for e in events if e.kind == "note.edited"]
+    status_sets = [e for e in events if e.kind == "task.status.set"]
+
+    closes_by_day: dict[date, int] = defaultdict(int)
+    creates_by_day: dict[date, int] = defaultdict(int)
+    edits_by_note: dict[str, int] = defaultdict(int)
+    edits_by_day_per_note: dict[tuple[date, str], int] = defaultdict(int)
+    active_days: set[date] = set()
+
+    for ev in closes:
+        d = event_local_date(ev.ts, tz_name)
+        closes_by_day[d] += 1
+        active_days.add(d)
+    for ev in creates:
+        d = event_local_date(ev.ts, tz_name)
+        creates_by_day[d] += 1
+        active_days.add(d)
+    for ev in edits:
+        d = event_local_date(ev.ts, tz_name)
+        edits_by_note[ev.ref] += 1
+        edits_by_day_per_note[(d, ev.ref)] += 1
+        active_days.add(d)
+
+    return BadgeContext(
+        s=s, user_id=user_id, tz_name=tz_name, today=today, events=events,
+        closes=closes, note_creates=creates, note_edits=edits,
+        status_sets=status_sets,
+        closes_by_day=closes_by_day, creates_by_day=creates_by_day,
+        edits_by_note=edits_by_note, edits_by_day_per_note=edits_by_day_per_note,
+        active_days=active_days,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Predicates
+# ---------------------------------------------------------------------------
+
+def _first_light(ctx: BadgeContext) -> bool:
+    return len(ctx.closes) >= 1
+
+
+def _hat_trick(ctx: BadgeContext) -> bool:
+    return any(c >= 3 for c in ctx.closes_by_day.values())
+
+
+def _docs_day(ctx: BadgeContext) -> bool:
+    return any(c >= 3 for c in ctx.creates_by_day.values())
+
+
+def _ghost_writer(ctx: BadgeContext) -> bool:
+    return any(c >= 10 for c in ctx.edits_by_day_per_note.values())
+
+
+def _curator(ctx: BadgeContext) -> bool:
+    return any(c >= 5 for c in ctx.edits_by_note.values())
+
+
+def _centurion(ctx: BadgeContext) -> bool:
+    return len(ctx.closes) >= 100
+
+
+def _marathoner(ctx: BadgeContext) -> bool:
+    s = compute_streak(ctx.active_days, ctx.today)
+    return max(s["current"], s["longest"]) >= 10
+
+
+def _on_time(ctx: BadgeContext) -> bool:
+    hits = 0
+    for ev in ctx.closes:
+        if ctx.close_was_on_time(ev):
+            hits += 1
+            if hits >= 10:
+                return True
+    return False
+
+
+def _polyglot(ctx: BadgeContext) -> bool:
+    by_day_proj: dict[date, set[str]] = defaultdict(set)
+    for ev in ctx.closes:
+        proj = ctx.project_for(ev.ref)
+        if proj:
+            by_day_proj[event_local_date(ev.ts, ctx.tz_name)].add(proj)
+    if not by_day_proj:
+        return False
+    for anchor in sorted(by_day_proj.keys()):
+        union: set[str] = set()
+        for d, ps in by_day_proj.items():
+            if anchor <= d <= anchor + timedelta(days=6):
+                union |= ps
+                if len(union) >= 5:
+                    return True
+    return False
+
+
+def _cleanup_crew(ctx: BadgeContext) -> bool:
+    aged_dates: list[date] = []
+    for ev in ctx.closes:
+        age = ctx.task_age_days(ev)
+        if age is not None and age >= 30:
+            aged_dates.append(event_local_date(ev.ts, ctx.tz_name))
+    aged_dates.sort()
+    for anchor in aged_dates:
+        if sum(1 for d in aged_dates if anchor <= d <= anchor + timedelta(days=6)) >= 5:
+            return True
+    return False
+
+
+def _weekend_warrior(ctx: BadgeContext) -> bool:
+    return any(
+        event_local_date(ev.ts, ctx.tz_name).weekday() >= 5
+        for ev in ctx.closes
+    )
+
+
+def _quiet_hours(ctx: BadgeContext) -> bool:
+    tz = resolve_tz(ctx.tz_name)
+    for ev in ctx.closes:
+        ts = ev.ts.replace(tzinfo=timezone.utc) if ev.ts.tzinfo is None else ev.ts
+        local_t = ts.astimezone(tz).time()
+        if local_t >= time(22, 0) or local_t < time(6, 0):
+            return True
+    return False
+
+
+def _phoenix(ctx: BadgeContext) -> bool:
+    closed_count: dict[str, int] = defaultdict(int)
+    seen_reopen: set[str] = set()
+    for ev in sorted(ctx.events, key=lambda e: e.ts):
+        if ev.kind == "task.closed":
+            closed_count[ev.ref] += 1
+            if ev.ref in seen_reopen and closed_count[ev.ref] >= 2:
+                return True
+        elif ev.kind == "task.status.set":
+            try:
+                meta = json.loads(ev.meta_json) if ev.meta_json else {}
+            except Exception:
+                meta = {}
+            if (str(meta.get("from") or "").lower() == "done"
+                    and str(meta.get("to") or "").lower() != "done"
+                    and closed_count.get(ev.ref, 0) >= 1):
+                seen_reopen.add(ev.ref)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Badge:
+    key: str
+    title: str
+    description: str
+    hidden: bool
+    check: Callable[[BadgeContext], bool]
+    progress: Optional[Callable[[BadgeContext], str]] = None
+
+
+def _prog_count(target: int, getter: Callable[[BadgeContext], int]):
+    def fn(ctx: BadgeContext) -> str:
+        n = getter(ctx)
+        return f"{min(n, target)}/{target}"
+    return fn
+
+
+def _prog_streak(target: int):
+    def fn(ctx: BadgeContext) -> str:
+        st = compute_streak(ctx.active_days, ctx.today)
+        cur = max(st["current"], st["longest"])
+        return f"{min(cur, target)}/{target} day(s)"
+    return fn
+
+
+CATALOG: tuple[Badge, ...] = (
+    Badge("first_light", "First Light",
+          "Close your first task.", False, _first_light,
+          _prog_count(1, lambda c: len(c.closes))),
+    Badge("hat_trick", "Hat Trick",
+          "Close 3 tasks in a single day.", False, _hat_trick,
+          _prog_count(3, lambda c: max(c.closes_by_day.values(), default=0))),
+    Badge("marathoner", "Marathoner",
+          "Maintain a 10-day activity streak.", False, _marathoner,
+          _prog_streak(10)),
+    Badge("centurion", "Centurion",
+          "Close 100 tasks lifetime.", False, _centurion,
+          _prog_count(100, lambda c: len(c.closes))),
+    Badge("on_time", "On Time",
+          "Close 10 tasks on or before their ETA (ISO dates only).",
+          False, _on_time),
+    Badge("curator", "Curator",
+          "Edit the same note 5 or more times.", False, _curator,
+          _prog_count(5, lambda c: max(c.edits_by_note.values(), default=0))),
+    Badge("docs_day", "Docs Day",
+          "Create 3 notes in a single day.", False, _docs_day,
+          _prog_count(3, lambda c: max(c.creates_by_day.values(), default=0))),
+    Badge("polyglot", "Polyglot",
+          "Touch 5 distinct projects via closes in one 7-day window.",
+          False, _polyglot),
+    Badge("cleanup_crew", "Cleanup Crew",
+          "Close 5 tasks aged ≥30 days in one 7-day window.",
+          False, _cleanup_crew),
+    # Hidden / easter-egg badges.
+    Badge("weekend_warrior", "Weekend Warrior",
+          "Close a task on a Saturday or Sunday (your local time).",
+          True, _weekend_warrior),
+    Badge("quiet_hours", "Quiet Hours",
+          "Close a task between 22:00 and 06:00 local time.",
+          True, _quiet_hours),
+    Badge("ghost_writer", "Ghost Writer",
+          "Edit the same note 10 or more times in a single day.",
+          True, _ghost_writer),
+    Badge("phoenix", "Phoenix",
+          "Re-open a closed task and close it again.",
+          True, _phoenix),
+)
+
+CATALOG_BY_KEY: dict[str, Badge] = {b.key: b for b in CATALOG}
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+def recompute_badges(s: Session, user_id: int) -> list[str]:
+    """Award any newly-earned badges for ``user_id``. Returns the list of
+    keys awarded *this call* so callers can announce them. Idempotent —
+    existing awards are skipped (UNIQUE index also guards at the DB layer).
+
+    Failures are swallowed: gamification must never break the parent
+    request.
+    """
+    try:
+        ctx = _build_context(s, user_id)
+        owned = {
+            row.badge_key for row in s.exec(
+                select(UserBadge).where(UserBadge.user_id == user_id)
+            ).all()
+        }
+        newly: list[str] = []
+        for badge in CATALOG:
+            if badge.key in owned:
+                continue
+            try:
+                if badge.check(ctx):
+                    s.add(UserBadge(
+                        user_id=user_id, badge_key=badge.key,
+                        awarded_at=datetime.utcnow(),
+                    ))
+                    newly.append(badge.key)
+            except Exception:  # pragma: no cover
+                log.exception("badge check failed: %s", badge.key)
+        if newly:
+            s.flush()
+        return newly
+    except Exception:  # pragma: no cover
+        log.exception("recompute_badges failed for user_id=%s", user_id)
+        return []
+
+
+def list_badges(s: Session, user_id: int) -> dict[str, Any]:
+    """Return earned + locked + hidden_locked counts for ``user_id``."""
+    ctx = _build_context(s, user_id)
+    owned_rows = s.exec(
+        select(UserBadge).where(UserBadge.user_id == user_id)
+    ).all()
+    owned_at: dict[str, datetime] = {r.badge_key: r.awarded_at for r in owned_rows}
+
+    earned: list[dict[str, Any]] = []
+    locked: list[dict[str, Any]] = []
+    hidden_locked = 0
+    for badge in CATALOG:
+        if badge.key in owned_at:
+            earned.append({
+                "key": badge.key,
+                "title": badge.title,
+                "description": badge.description,
+                "awarded_at": owned_at[badge.key].isoformat(),
+            })
+            continue
+        if badge.hidden:
+            hidden_locked += 1
+            continue
+        progress = badge.progress(ctx) if badge.progress else None
+        locked.append({
+            "key": badge.key,
+            "title": badge.title,
+            "description": badge.description,
+            "progress": progress,
+        })
+    return {
+        "earned": earned,
+        "locked": locked,
+        "hidden_locked_count": hidden_locked,
+        "total_count": len(CATALOG),
+    }

--- a/VegaNotes/backend/app/db.py
+++ b/VegaNotes/backend/app/db.py
@@ -45,6 +45,9 @@ def init_db() -> None:
             conn.execute(text("ALTER TABLE user ADD COLUMN pass_hash TEXT NOT NULL DEFAULT ''"))
         if user_cols and "is_admin" not in user_cols:
             conn.execute(text("ALTER TABLE user ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0"))
+        if user_cols and "tz" not in user_cols:
+            # Per-user IANA TZ for gamification (Phase 3). Empty ≡ UTC.
+            conn.execute(text("ALTER TABLE user ADD COLUMN tz TEXT NOT NULL DEFAULT ''"))
         # Normalise legacy priority value_norm rows: old indexer stored 'p0'-'p3'
         # as the value_norm; new indexer stores the integer rank ('0'-'3').
         # Re-write any non-numeric priority value_norm to the integer rank.
@@ -64,6 +67,20 @@ def init_db() -> None:
         conn.execute(text(
             "CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts "
             "USING fts5(title, body_md);"
+        ))
+        # Composite index for the gamification activity log: per-user time
+        # range scans dominate the read pattern (`/api/me/activity`,
+        # streak/stats math). Single-column indexes on user_id and ts
+        # already exist via the model definition; this composite makes the
+        # common WHERE user_id=? AND ts>=? query a single index seek.
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_activityevent_user_ts "
+            "ON activityevent(user_id, ts);"
+        ))
+        # Idempotency guard for badge awards: one (user, badge) row max.
+        conn.execute(text(
+            "CREATE UNIQUE INDEX IF NOT EXISTS ix_userbadge_user_key "
+            "ON userbadge(user_id, badge_key);"
         ))
         # Bidirectional view over `link` (treats every edge as undirected).
         conn.execute(text(

--- a/VegaNotes/backend/app/gamify.py
+++ b/VegaNotes/backend/app/gamify.py
@@ -1,0 +1,139 @@
+"""Gamification event log — Phase 1 foundation.
+
+This module owns the *write side* of the gamification subsystem: a single
+``record_event`` helper that API write-handlers call after a successful
+mutation. Reads (stats, badges, streaks) live in higher phases.
+
+Design notes
+------------
+- All writes are **best-effort**: an exception inside ``record_event`` MUST
+  NOT fail the parent request. We swallow and log instead. Gamification is
+  decoration, never a correctness concern.
+- The actor is the *authenticated user*, not the task owner. "What I did"
+  semantics — closing someone else's task still counts as my close.
+- Events are append-only. There is no update path. ``vn me reset`` will
+  delete-by-user_id (Phase 4).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlmodel import Session, select
+
+from .models import ActivityEvent, User
+
+log = logging.getLogger(__name__)
+
+
+# Event kind constants. Centralised so callers + tests share spelling.
+TASK_CREATED = "task.created"
+TASK_STATUS_SET = "task.status.set"
+TASK_CLOSED = "task.closed"
+NOTE_CREATED = "note.created"
+NOTE_EDITED = "note.edited"
+
+
+def record_event(
+    s: Session,
+    user_name: str,
+    kind: str,
+    ref: str = "",
+    meta: Optional[dict[str, Any]] = None,
+    *,
+    ts: Optional[datetime] = None,
+) -> list[str]:
+    """Append one ActivityEvent for ``user_name`` and run badge
+    recompute. Failure is swallowed.
+
+    ``ref`` is a free-form subject identifier (task uuid, note path, …).
+    ``meta`` is JSON-encoded into ``meta_json``.
+
+    Returns the list of badge keys newly awarded by this event (empty if
+    none — also empty on any internal failure, since gamification is
+    decoration, never a correctness concern).
+    """
+    try:
+        u = s.exec(select(User).where(User.name == user_name)).first()
+        if u is None or u.id is None:
+            return []
+        ev = ActivityEvent(
+            user_id=u.id,
+            kind=kind,
+            ref=ref or "",
+            ts=ts or datetime.utcnow(),
+            meta_json=json.dumps(meta, sort_keys=True) if meta else "",
+        )
+        s.add(ev)
+        s.flush()
+        # Recompute badges on every event. Cheap (one user's events) and
+        # keeps awards close to the action that earned them.
+        from . import badges as _badges  # local import: avoid circular
+        return _badges.recompute_badges(s, u.id)
+    except Exception:  # pragma: no cover - defensive
+        log.exception("record_event failed (kind=%s ref=%s)", kind, ref)
+        return []
+
+
+def backfill(s: Session) -> dict[str, int]:
+    """One-shot reconstruction of historical events from existing rows.
+
+    Idempotent: removes any prior backfill rows (``meta.source == 'backfill'``)
+    before re-emitting, so re-running after data fixes is safe.
+
+    Strategy (intentionally minimal — historical actor is unknown):
+      * For every Task with at least one owner, emit ``task.created`` per
+        (task, owner) at ``task.created_at``.
+      * For every Task whose status is ``done``, additionally emit
+        ``task.closed`` per (task, owner) at ``task.updated_at``.
+      * Notes have no recorded author and are NOT backfilled.
+
+    Returns counts for observability.
+    """
+    from sqlalchemy import text as _text  # local: avoid top-level coupling
+
+    s.exec(
+        _text(
+            "DELETE FROM activityevent "
+            "WHERE meta_json LIKE '%\"source\": \"backfill\"%'"
+        )
+    )
+    from .models import Task, TaskOwner  # local to avoid circular at import
+
+    created = 0
+    closed = 0
+    rows = s.exec(
+        select(Task, TaskOwner, User)
+        .join(TaskOwner, TaskOwner.task_id == Task.id)
+        .join(User, User.id == TaskOwner.user_id)
+    ).all()
+    for t, _own, u in rows:
+        if u.id is None:
+            continue
+        meta_seed = {"source": "backfill"}
+        if t.task_uuid:
+            meta_seed["task_uuid"] = t.task_uuid
+        s.add(ActivityEvent(
+            user_id=u.id,
+            kind=TASK_CREATED,
+            ref=t.task_uuid or f"task#{t.id}",
+            ts=t.created_at,
+            meta_json=json.dumps(meta_seed, sort_keys=True),
+        ))
+        created += 1
+        if (t.status or "").lower() == "done":
+            close_meta = dict(meta_seed)
+            close_meta["from"] = ""
+            close_meta["to"] = "done"
+            s.add(ActivityEvent(
+                user_id=u.id,
+                kind=TASK_CLOSED,
+                ref=t.task_uuid or f"task#{t.id}",
+                ts=t.updated_at,
+                meta_json=json.dumps(close_meta, sort_keys=True),
+            ))
+            closed += 1
+    s.flush()
+    return {"task_created": created, "task_closed": closed}

--- a/VegaNotes/backend/app/gamify_stats.py
+++ b/VegaNotes/backend/app/gamify_stats.py
@@ -1,0 +1,296 @@
+"""Gamification Phase 2: read-only personal stats.
+
+Pure-Python summarisers over the ``ActivityEvent`` log written by Phase 1.
+All bucket boundaries (today / week / month / streak day) honour the
+**user's IANA timezone** (``User.tz``); empty tz ≡ UTC. All reads are
+caller-scoped at the endpoint layer — this module never reaches across
+users.
+"""
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+try:
+    from zoneinfo import ZoneInfo  # py>=3.9
+except ImportError:  # pragma: no cover
+    ZoneInfo = None  # type: ignore[assignment]
+
+from sqlalchemy import text as _text
+from sqlmodel import Session, select
+
+from .models import ActivityEvent, Note, Task, TaskAttr, User
+
+
+# ---- TZ helpers -----------------------------------------------------------
+
+def resolve_tz(name: str) -> "timezone | ZoneInfo":
+    """Return a tzinfo for ``name`` (IANA) — falling back to UTC silently
+    if zoneinfo isn't available or the name is unknown.
+    """
+    if not name:
+        return timezone.utc
+    if ZoneInfo is None:
+        return timezone.utc
+    try:
+        return ZoneInfo(name)
+    except Exception:
+        return timezone.utc
+
+
+def event_local_date(ts: datetime, tz_name: str) -> date:
+    """Map a stored UTC timestamp to a calendar date in the user's TZ."""
+    tz = resolve_tz(tz_name)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(tz).date()
+
+
+def user_today(tz_name: str) -> date:
+    """The user's current local calendar date."""
+    return datetime.now(tz=timezone.utc).astimezone(resolve_tz(tz_name)).date()
+
+
+# ---- path helper (project = top folder) -----------------------------------
+
+def _project_for_path(rel_path: str) -> Optional[str]:
+    parts = Path(rel_path).parts
+    return parts[0] if len(parts) >= 2 else None
+
+
+# ---- pure streak computation ---------------------------------------------
+
+def compute_streak(
+    active_days: set[date],
+    today: date,
+    *,
+    rest_tokens_per_window: int = 2,
+    window_days: int = 14,
+) -> dict[str, int]:
+    """Compute current and longest streak over a set of active days.
+
+    Walks backward from ``today``: each active day extends the streak;
+    each inactive day is held in a *buffer* that is only committed as a
+    consumed rest token if a later active day actually bridges across it.
+    The streak ends when buffered + already-consumed tokens would exceed
+    ``rest_tokens_per_window`` within any trailing ``window_days`` window.
+
+    Tokens held speculatively (i.e. never bridged) do not count against
+    ``rest_tokens_remaining`` — so a long lapse beyond the streak's true
+    end doesn't punish you.
+
+    Longest streak: same algorithm pinned at every active day in turn.
+    O(n²) worst case but n is small in practice (one row per active day).
+    """
+    if not active_days:
+        return {"current": 0, "longest": 0, "rest_tokens_remaining": rest_tokens_per_window}
+
+    def _walk_back(start: date) -> tuple[int, list[date]]:
+        """Returns (streak_length, committed_token_dates)."""
+        current = 0
+        committed: list[date] = []
+        buffer: list[date] = []
+        cursor = start
+        guard = 0
+        while guard < 366 * 5:
+            guard += 1
+            if cursor in active_days:
+                for d in buffer:
+                    committed.append(d)
+                buffer = []
+                current += 1
+            else:
+                cutoff = cursor - timedelta(days=window_days - 1)
+                committed_in_window = [d for d in committed if d >= cutoff]
+                if len(committed_in_window) + len(buffer) + 1 > rest_tokens_per_window:
+                    break
+                buffer.append(cursor)
+            cursor -= timedelta(days=1)
+        cutoff = start - timedelta(days=window_days - 1)
+        committed_recent = [d for d in committed if d >= cutoff]
+        return current, committed_recent
+
+    current, committed_recent = _walk_back(today)
+    longest = current
+    for d in active_days:
+        if d > today:
+            continue
+        c, _ = _walk_back(d)
+        if c > longest:
+            longest = c
+
+    return {
+        "current": current,
+        "longest": longest,
+        "rest_tokens_remaining": max(0, rest_tokens_per_window - len(committed_recent)),
+    }
+
+
+# ---- compute pipeline -----------------------------------------------------
+
+def _events_for(s: Session, user_id: int, since: Optional[date] = None) -> list[ActivityEvent]:
+    q = select(ActivityEvent).where(ActivityEvent.user_id == user_id)
+    if since is not None:
+        q = q.where(ActivityEvent.ts >= datetime.combine(since, datetime.min.time()))
+    return list(s.exec(q.order_by(ActivityEvent.ts.asc())).all())
+
+
+def _task_by_uuid(s: Session, task_uuid: str) -> Optional[Task]:
+    return s.exec(select(Task).where(Task.task_uuid == task_uuid)).first()
+
+
+def _task_attr(s: Session, task_id: int, key: str) -> Optional[str]:
+    row = s.exec(
+        select(TaskAttr).where(TaskAttr.task_id == task_id, TaskAttr.key == key)
+    ).first()
+    return row.value if row else None
+
+
+def _is_on_time(close_local_date: date, eta_value: str) -> Optional[bool]:
+    """Return True if closed on or before ``eta_value``, False if late.
+
+    Returns None when ``eta_value`` is in a format we don't yet parse
+    (e.g. ``ww18``); the caller excludes those from the rate.
+    """
+    if not eta_value:
+        return None
+    try:
+        eta_d = datetime.fromisoformat(eta_value.strip()).date()
+    except ValueError:
+        return None
+    return close_local_date <= eta_d
+
+
+def _user_tz_name(s: Session, user_id: int) -> str:
+    u = s.get(User, user_id)
+    return (u.tz if u else "") or ""
+
+
+def compute_stats(
+    s: Session,
+    user_id: int,
+    *,
+    today: Optional[date] = None,
+    tz_name: Optional[str] = None,
+) -> dict[str, Any]:
+    if tz_name is None:
+        tz_name = _user_tz_name(s, user_id)
+    today = today or user_today(tz_name)
+    week_start = today - timedelta(days=6)
+    month_start = today - timedelta(days=29)
+
+    events = _events_for(s, user_id)
+
+    closes_today = closes_week = closes_month = closes_lifetime = 0
+    notes_week = notes_month = 0
+    by_kind: dict[str, int] = defaultdict(int)
+    project_counts: dict[str, int] = defaultdict(int)
+    on_time_hits = on_time_total = 0
+    active_days: set[date] = set()
+
+    for ev in events:
+        d = event_local_date(ev.ts, tz_name)
+        if ev.kind == "task.closed":
+            closes_lifetime += 1
+            if d == today:
+                closes_today += 1
+            if d >= week_start:
+                closes_week += 1
+            if d >= month_start:
+                closes_month += 1
+            active_days.add(d)
+            if ev.ref:
+                t = _task_by_uuid(s, ev.ref)
+                if t is not None:
+                    by_kind[(t.kind or "task")] += 1
+                    if d >= month_start:
+                        note = s.get(Note, t.note_id)
+                        if note:
+                            proj = _project_for_path(note.path)
+                            if proj:
+                                project_counts[proj] += 1
+                        eta = _task_attr(s, t.id, "eta") if t.id is not None else None
+                        verdict = _is_on_time(d, eta or "")
+                        if verdict is not None:
+                            on_time_total += 1
+                            if verdict:
+                                on_time_hits += 1
+        elif ev.kind in ("note.created", "note.edited"):
+            if d >= week_start:
+                notes_week += 1
+            if d >= month_start:
+                notes_month += 1
+            active_days.add(d)
+
+    streak = compute_streak(active_days, today)
+    favorite_project = (
+        max(project_counts.items(), key=lambda kv: kv[1])[0]
+        if project_counts else None
+    )
+    on_time_rate = (on_time_hits / on_time_total) if on_time_total else None
+
+    return {
+        "as_of": today.isoformat(),
+        "tz": tz_name or "UTC",
+        "tasks_closed": {
+            "today": closes_today,
+            "week": closes_week,
+            "month": closes_month,
+            "lifetime": closes_lifetime,
+        },
+        "notes_touched": {"week": notes_week, "month": notes_month},
+        "current_streak_days": streak["current"],
+        "longest_streak_days": streak["longest"],
+        "rest_tokens_remaining": streak["rest_tokens_remaining"],
+        "on_time_eta_rate_30d": round(on_time_rate, 4) if on_time_rate is not None else None,
+        "on_time_sample_30d": on_time_total,
+        "favorite_project_30d": favorite_project,
+        "by_kind": dict(by_kind),
+    }
+
+
+def compute_history(
+    s: Session,
+    user_id: int,
+    *,
+    days: int = 30,
+    today: Optional[date] = None,
+    tz_name: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    if tz_name is None:
+        tz_name = _user_tz_name(s, user_id)
+    today = today or user_today(tz_name)
+    start = today - timedelta(days=days - 1)
+    # Pull events from a slightly-padded UTC window; TZ shift can move an
+    # event into a different local date than its UTC date suggests.
+    pad_dt = datetime.combine(start - timedelta(days=2), datetime.min.time())
+
+    closes: dict[date, int] = defaultdict(int)
+    edits: dict[date, int] = defaultdict(int)
+    rows = s.exec(
+        select(ActivityEvent)
+        .where(ActivityEvent.user_id == user_id)
+        .where(ActivityEvent.ts >= pad_dt)
+    ).all()
+    for ev in rows:
+        d = event_local_date(ev.ts, tz_name)
+        if d < start or d > today:
+            continue
+        if ev.kind == "task.closed":
+            closes[d] += 1
+        elif ev.kind in ("note.created", "note.edited"):
+            edits[d] += 1
+
+    out: list[dict[str, Any]] = []
+    for i in range(days):
+        d = start + timedelta(days=i)
+        out.append({
+            "date": d.isoformat(),
+            "closes": closes.get(d, 0),
+            "edits": edits.get(d, 0),
+        })
+    return out
+

--- a/VegaNotes/backend/app/models/__init__.py
+++ b/VegaNotes/backend/app/models/__init__.py
@@ -49,6 +49,10 @@ class User(SQLModel, table=True):
     saved_views_json: str = "[]"
     pass_hash: str = ""
     is_admin: bool = False
+    # IANA tz name (e.g. "America/Los_Angeles"). Used by gamification stats
+    # so streaks roll over at the user's local midnight, not UTC's. Empty
+    # string ≡ UTC (the historical default).
+    tz: str = ""
 
 
 class TaskOwner(SQLModel, table=True):
@@ -86,6 +90,36 @@ class Link(SQLModel, table=True):
     src_task_id: int = Field(foreign_key="task.id", index=True)
     dst_slug: str = Field(index=True)
     kind: str = "task"  # task | link | blocks | blocked_by
+
+
+class ActivityEvent(SQLModel, table=True):
+    """Append-only log of user actions for gamification stats / badges.
+
+    One row per atomic event (task close, note edit, …). The actor is the
+    authenticated user that issued the API call — not the task owner. All
+    reads are scoped to the calling user via ``/api/me/activity``; this
+    table is never exposed cross-user.
+    """
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    kind: str = Field(index=True)
+    # Free-form reference for the event subject (e.g. "T-ABC123" or note
+    # path). Indexed so we can ask "all events touching this task".
+    ref: str = Field(default="", index=True)
+    ts: datetime = Field(default_factory=datetime.utcnow, index=True)
+    # JSON blob with event-specific fields (e.g. {"from":"todo","to":"done"}).
+    # Source-of-truth for badge logic; intentionally untyped.
+    meta_json: str = ""
+
+
+class UserBadge(SQLModel, table=True):
+    """One row per (user, badge) award. Awarding is idempotent: the
+    composite uniqueness is enforced by an index in db.init_db so a
+    re-run of recompute_badges never double-awards."""
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    badge_key: str = Field(index=True)
+    awarded_at: datetime = Field(default_factory=datetime.utcnow)
 
 
 class ProjectMember(SQLModel, table=True):

--- a/VegaNotes/backend/tests/api/test_gamify_badges.py
+++ b/VegaNotes/backend/tests/api/test_gamify_badges.py
@@ -1,0 +1,345 @@
+"""Phase 3 gamification: badges + per-user TZ.
+
+Drives the system through ``record_event`` directly so each test can
+construct the precise event log that should (or shouldn't) earn a given
+badge. The HTTP surface is exercised separately — endpoints just call
+into ``list_badges`` / the TZ setter.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+DATA = Path(tempfile.mkdtemp(prefix="vega-badges-"))
+os.environ["VEGANOTES_DATA_DIR"] = str(DATA)
+os.environ["VEGANOTES_SERVE_STATIC"] = "false"
+
+from app.main import app  # noqa: E402
+from app.db import get_engine  # noqa: E402
+from app.models import (  # noqa: E402
+    ActivityEvent, Note, Task, TaskAttr, User, UserBadge,
+)
+from app import badges as badges_mod  # noqa: E402
+
+ADMIN = "Basic " + base64.b64encode(b"admin:admin").decode()
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+    shutil.rmtree(DATA, ignore_errors=True)
+
+
+def _user_id(s: Session, name: str = "admin") -> int:
+    u = s.exec(select(User).where(User.name == name)).first()
+    assert u is not None
+    return u.id  # type: ignore[return-value]
+
+
+def _wipe(s: Session, uid: int) -> None:
+    """Reset gamification state for a user between tests."""
+    for ev in s.exec(select(ActivityEvent).where(ActivityEvent.user_id == uid)).all():
+        s.delete(ev)
+    for b in s.exec(select(UserBadge).where(UserBadge.user_id == uid)).all():
+        s.delete(b)
+    s.commit()
+
+
+def _add_event(
+    s: Session,
+    uid: int,
+    kind: str,
+    *,
+    ref: str = "",
+    ts: datetime,
+    meta: dict | None = None,
+) -> None:
+    s.add(ActivityEvent(
+        user_id=uid, kind=kind, ref=ref, ts=ts,
+        meta_json=json.dumps(meta, sort_keys=True) if meta else "",
+    ))
+    s.commit()
+
+
+def _earned(s: Session, uid: int) -> set[str]:
+    return {
+        r.badge_key for r in s.exec(
+            select(UserBadge).where(UserBadge.user_id == uid)
+        ).all()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Endpoint smoke + TZ
+# ---------------------------------------------------------------------------
+
+def test_badges_endpoint_shape(client):
+    r = client.get("/api/me/badges", headers={"Authorization": ADMIN})
+    assert r.status_code == 200, r.text
+    data = r.json()
+    for k in ("earned", "locked", "hidden_locked_count", "total_count"):
+        assert k in data
+    assert data["total_count"] == len(badges_mod.CATALOG)
+    assert isinstance(data["earned"], list)
+    assert isinstance(data["locked"], list)
+
+
+def test_set_tz_valid(client):
+    r = client.patch(
+        "/api/me/tz", json={"tz": "America/Los_Angeles"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["tz"] == "America/Los_Angeles"
+    me = client.get("/api/me", headers={"Authorization": ADMIN}).json()
+    assert me["tz"] == "America/Los_Angeles"
+
+
+def test_set_tz_empty_means_utc(client):
+    r = client.patch(
+        "/api/me/tz", json={"tz": ""},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 200
+    assert r.json()["tz"] == "UTC"
+
+
+def test_set_tz_rejects_unknown(client):
+    r = client.patch(
+        "/api/me/tz", json={"tz": "Mars/Olympus"},
+        headers={"Authorization": ADMIN},
+    )
+    assert r.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Badge predicates — driven by direct event injection
+# ---------------------------------------------------------------------------
+
+def test_first_light_awarded_on_single_close():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        _add_event(s, uid, "task.closed", ref="T-A", ts=datetime.utcnow())
+        new = badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "first_light" in new
+        assert "first_light" in _earned(s, uid)
+
+
+def test_recompute_is_idempotent():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        _add_event(s, uid, "task.closed", ref="T-A", ts=datetime.utcnow())
+        badges_mod.recompute_badges(s, uid)
+        s.commit()
+        new2 = badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert new2 == []  # no double-award
+        owned = list(s.exec(
+            select(UserBadge).where(UserBadge.user_id == uid)
+        ).all())
+        # First Light shows exactly once even after a second pass.
+        assert sum(1 for r in owned if r.badge_key == "first_light") == 1
+
+
+def test_hat_trick_three_closes_same_day():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        base = datetime.utcnow().replace(hour=12, minute=0, second=0, microsecond=0)
+        for i in range(3):
+            _add_event(s, uid, "task.closed", ref=f"T-H{i}",
+                       ts=base + timedelta(minutes=i))
+        new = badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "hat_trick" in new
+
+
+def test_docs_day_three_creates_same_day():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        base = datetime.utcnow().replace(hour=10, minute=0, second=0, microsecond=0)
+        for i in range(3):
+            _add_event(s, uid, "note.created", ref=f"docs-{i}.md",
+                       ts=base + timedelta(minutes=i))
+        new = badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "docs_day" in new
+
+
+def test_curator_five_edits_same_note():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        base = datetime.utcnow()
+        for i in range(5):
+            _add_event(s, uid, "note.edited", ref="same.md",
+                       ts=base + timedelta(hours=i))
+        new = badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "curator" in new
+
+
+def test_ghost_writer_ten_edits_one_day_one_note():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        base = datetime.utcnow().replace(hour=8, minute=0, second=0, microsecond=0)
+        for i in range(10):
+            _add_event(s, uid, "note.edited", ref="ghost.md",
+                       ts=base + timedelta(minutes=i * 30))
+        badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "ghost_writer" in _earned(s, uid)
+        # Curator also fires (same edits >=5 of same note).
+        assert "curator" in _earned(s, uid)
+
+
+def test_marathoner_ten_consecutive_active_days():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        # Place activity on 10 consecutive days ending today (UTC).
+        today_utc = datetime.utcnow().replace(hour=12, minute=0, second=0, microsecond=0)
+        for i in range(10):
+            _add_event(s, uid, "task.closed", ref=f"T-M{i}",
+                       ts=today_utc - timedelta(days=i))
+        badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "marathoner" in _earned(s, uid)
+
+
+def test_weekend_warrior_close_on_saturday():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        # Find an upcoming Saturday at noon UTC; user TZ is whatever they
+        # last set — clear it to UTC for determinism.
+        u = s.exec(select(User).where(User.id == uid)).first()
+        u.tz = ""
+        s.add(u); s.commit()
+        d = datetime(2024, 1, 6, 12, 0, 0)  # Saturday
+        assert d.weekday() == 5
+        _add_event(s, uid, "task.closed", ref="T-WK", ts=d)
+        badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "weekend_warrior" in _earned(s, uid)
+
+
+def test_quiet_hours_late_night_close():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        u = s.exec(select(User).where(User.id == uid)).first()
+        u.tz = ""  # UTC for determinism
+        s.add(u); s.commit()
+        d = datetime(2024, 3, 5, 23, 30, 0)  # 23:30 UTC, Tuesday (not weekend)
+        _add_event(s, uid, "task.closed", ref="T-QH", ts=d)
+        badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "quiet_hours" in _earned(s, uid)
+
+
+def test_phoenix_close_reopen_close():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        base = datetime.utcnow() - timedelta(days=2)
+        _add_event(s, uid, "task.closed", ref="T-PHX", ts=base)
+        _add_event(s, uid, "task.status.set", ref="T-PHX",
+                   ts=base + timedelta(hours=1),
+                   meta={"from": "done", "to": "todo"})
+        _add_event(s, uid, "task.closed", ref="T-PHX",
+                   ts=base + timedelta(hours=2))
+        badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "phoenix" in _earned(s, uid)
+
+
+def test_centurion_requires_100_closes():
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        base = datetime.utcnow() - timedelta(days=200)
+        for i in range(99):
+            _add_event(s, uid, "task.closed", ref=f"T-C{i}",
+                       ts=base + timedelta(hours=i))
+        badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "centurion" not in _earned(s, uid)
+        _add_event(s, uid, "task.closed", ref="T-C99",
+                   ts=base + timedelta(hours=200))
+        badges_mod.recompute_badges(s, uid)
+        s.commit()
+        assert "centurion" in _earned(s, uid)
+
+
+# ---------------------------------------------------------------------------
+# Hook integration
+# ---------------------------------------------------------------------------
+
+def test_record_event_awards_first_light(client):
+    """Closing a task via the public API should award First Light if not
+    already earned."""
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+    # Create + close a task via real endpoints.
+    client.put(
+        "/api/notes", json={"path": "p3-hook.md", "body_md": "# h\n"},
+        headers={"Authorization": ADMIN},
+    )
+    r = client.post(
+        "/api/tasks",
+        json={"note_path": "p3-hook.md", "title": "hook me", "owners": ["admin"]},
+        headers={"Authorization": ADMIN},
+    )
+    ref = r.json()["task_uuid"]
+    client.patch(
+        f"/api/tasks/{ref}", json={"status": "done"},
+        headers={"Authorization": ADMIN},
+    )
+    bad = client.get("/api/me/badges", headers={"Authorization": ADMIN}).json()
+    keys = {b["key"] for b in bad["earned"]}
+    assert "first_light" in keys
+
+
+# ---------------------------------------------------------------------------
+# TZ-aware bucketing in compute_history / compute_stats
+# ---------------------------------------------------------------------------
+
+def test_history_respects_per_user_tz():
+    """An event at 23:00 PST on day D should bucket to D in PST and to
+    D+1 in UTC (since that's 07:00 UTC the next day)."""
+    from app.gamify_stats import compute_history
+    with Session(get_engine()) as s:
+        uid = _user_id(s)
+        _wipe(s, uid)
+        # Pick a UTC instant a few days ago at 05:00 UTC. That's
+        # 22:00 the prior day in PDT (UTC-7) and 21:00 the prior day in
+        # PST (UTC-8) — both safely "yesterday" in America/Los_Angeles.
+        anchor = (datetime.utcnow() - timedelta(days=3)).replace(
+            hour=5, minute=0, second=0, microsecond=0,
+        )
+        _add_event(s, uid, "task.closed", ref="T-TZ", ts=anchor)
+        utc_day = anchor.strftime("%Y-%m-%d")
+        la_day = (anchor - timedelta(days=1)).strftime("%Y-%m-%d")
+        utc_hist = {h["date"]: h["closes"] for h in
+                    compute_history(s, uid, days=30, tz_name="UTC")}
+        la_hist = {h["date"]: h["closes"] for h in
+                   compute_history(s, uid, days=30, tz_name="America/Los_Angeles")}
+        assert utc_hist.get(utc_day, 0) == 1
+        assert la_hist.get(la_day, 0) == 1

--- a/VegaNotes/tools/vn/README.md
+++ b/VegaNotes/tools/vn/README.md
@@ -233,6 +233,51 @@ The slug uses the same lowercase-kebab rule as the rest of VegaNotes
 
 Prints the authenticated user (and `(admin)` if applicable).
 
+### `vn me <subcommand>` — personal stats (gamification)
+
+Solo / self-progress mode: every stat is private to you. Reads only;
+nothing here changes data.
+
+```bash
+vn me stats                  # full stats card
+vn me streak                 # current + longest streak (with rest tokens)
+vn me history --days 30      # ANSI sparkline of closes/edits per day
+vn me activity               # recent event log
+vn me activity --kind task.closed --limit 20
+vn me activity --since 2026-04-01 --until 2026-04-15
+vn me badges                 # earned achievements
+vn me badges --all           # also list locked badges with progress
+vn me tz                     # show your IANA timezone (default UTC)
+vn me tz America/Los_Angeles # set timezone (streaks roll over locally)
+```
+
+`vn me stats` shows tasks closed (today / 7d / 30d / lifetime), notes
+touched (7d / 30d), current and longest streak, on-time-ETA rate over
+the last 30 days, your favorite project, and a per-kind breakdown.
+Streaks are forgiving: you have **2 rest tokens per rolling 14-day
+window**, so a single off day doesn't kill a long run.
+
+**Per-user timezone.** All day-bucketing (streaks, history, "today")
+uses the timezone you set with `vn me tz <IANA-name>`. Empty / unset
+≡ UTC. Set it once and a task closed at 23:30 your time stays on
+*your* calendar day instead of leaking into the next one.
+
+**Badges.** A small curated catalog of achievements you discover by
+using the tool — close your first task (First Light), three in a day
+(Hat Trick), maintain a 10-day streak (Marathoner), close 10 tasks on
+or before their ETA (On Time), and so on. A handful are hidden — the
+default `vn me badges` view rolls them into a "+N hidden" footer so
+you can find them naturally. Badges are personal: there's no
+leaderboard, no comparison, and admins cannot see another user's
+progress.
+
+Pass the global `--json` flag (before `me`) to get raw JSON for any
+subcommand:
+
+```bash
+vn --json me stats | jq .current_streak_days
+```
+
 ### `vn show <resource>` — read-only inspector
 
 Browse the database without curl-ing the API by hand. Every resource maps

--- a/VegaNotes/tools/vn/tests/test_cli.py
+++ b/VegaNotes/tools/vn/tests/test_cli.py
@@ -874,3 +874,206 @@ def test_list_mixed_columns_returns_2(fake_client, capsys):
     rc = cli.main(["list", "--columns", "id,+kind"])
     assert rc == 2
     assert "cannot mix" in capsys.readouterr().err
+
+
+# ---------- vn me <subcommand> ---------------------------------------------
+
+_FAKE_STATS = {
+    "as_of": "2026-04-27",
+    "tasks_closed": {"today": 3, "week": 11, "month": 28, "lifetime": 142},
+    "notes_touched": {"week": 6, "month": 19},
+    "current_streak_days": 7,
+    "longest_streak_days": 23,
+    "rest_tokens_remaining": 1,
+    "on_time_eta_rate_30d": 0.81,
+    "on_time_sample_30d": 26,
+    "favorite_project_30d": "ww18",
+    "by_kind": {"task": 26, "ar": 2},
+}
+
+
+def test_me_stats_renders_card(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/stats")] = _FAKE_STATS
+    rc = cli.main(["me", "stats"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "as of 2026-04-27" in out
+    assert "closed today      3" in out
+    assert "current streak    7 day(s)" in out
+    assert "favorite project  ww18" in out
+    assert "on-time ETA (30d) 81%" in out
+
+
+def test_me_stats_json_passthrough(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/stats")] = _FAKE_STATS
+    rc = cli.main(["--json", "me", "stats"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["current_streak_days"] == 7
+
+
+def test_me_streak_compact(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/streak")] = {
+        "current_streak_days": 5, "longest_streak_days": 11,
+        "rest_tokens_remaining": 2, "as_of": "2026-04-27",
+    }
+    rc = cli.main(["me", "streak"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "5 day(s)" in out
+    assert "longest: 11" in out
+    assert "rest tokens: 2" in out
+
+
+def test_me_streak_zero_no_flame(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/streak")] = {
+        "current_streak_days": 0, "longest_streak_days": 4,
+        "rest_tokens_remaining": 2, "as_of": "2026-04-27",
+    }
+    cli.main(["me", "streak"])
+    out = capsys.readouterr().out
+    # No flame when current == 0
+    assert "🔥" not in out
+
+
+def test_me_history_sparkline(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/history")] = [
+        {"date": "2026-04-21", "closes": 0, "edits": 1},
+        {"date": "2026-04-22", "closes": 2, "edits": 3},
+        {"date": "2026-04-23", "closes": 1, "edits": 0},
+    ]
+    rc = cli.main(["me", "history", "--days", "3"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "closes" in out and "edits" in out
+    assert "total 3" in out  # 0+2+1
+    assert "total 4" in out  # 1+3+0
+    # The history endpoint was called with the requested days param.
+    call = [c for c in fake_client.calls if c[1] == "/api/me/history"][0]
+    assert call[2] == {"days": 3}
+
+
+def test_me_history_empty(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/history")] = []
+    cli.main(["me", "history"])
+    assert "no activity" in capsys.readouterr().out
+
+
+def test_me_activity_filters(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/activity")] = [
+        {"id": 1, "kind": "task.closed", "ref": "T-X", "ts": "2026-04-27T10:00:00",
+         "meta": {"from": "todo", "to": "done"}},
+    ]
+    rc = cli.main(["me", "activity", "--kind", "task.closed", "--limit", "5"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "task.closed" in out and "T-X" in out
+    call = [c for c in fake_client.calls if c[1] == "/api/me/activity"][0]
+    assert call[2] == {"kind": "task.closed", "limit": 5}
+
+
+def test_me_activity_empty(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/activity")] = []
+    cli.main(["me", "activity"])
+    assert "no events" in capsys.readouterr().out
+
+
+def test_me_subcommand_required(fake_client, capsys):
+    with pytest.raises(SystemExit):
+        cli.main(["me"])
+
+
+# ---------- vn me badges / vn me tz (Phase 3) ------------------------------
+
+def test_me_badges_earned_only(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/badges")] = {
+        "earned": [
+            {"key": "first_light", "title": "First Light",
+             "description": "Close your first task.",
+             "awarded_at": "2026-04-20T10:00:00"},
+            {"key": "hat_trick", "title": "Hat Trick",
+             "description": "Close 3 tasks in a single day.",
+             "awarded_at": "2026-04-22T18:00:00"},
+        ],
+        "locked": [
+            {"key": "marathoner", "title": "Marathoner",
+             "description": "Maintain a 10-day activity streak.",
+             "progress": "7/10 day(s)"},
+        ],
+        "hidden_locked_count": 4,
+        "total_count": 13,
+    }
+    rc = cli.main(["me", "badges"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "earned (2/13)" in out
+    assert "First Light" in out and "Hat Trick" in out
+    # default view does NOT spoil locked-badge titles
+    assert "Marathoner" not in out
+    assert "more to unlock" in out
+
+
+def test_me_badges_all_shows_locked_and_hidden_count(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/badges")] = {
+        "earned": [],
+        "locked": [
+            {"key": "marathoner", "title": "Marathoner",
+             "description": "Maintain a 10-day activity streak.",
+             "progress": "3/10 day(s)"},
+        ],
+        "hidden_locked_count": 2,
+        "total_count": 13,
+    }
+    rc = cli.main(["me", "badges", "--all"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Marathoner" in out
+    assert "[3/10 day(s)]" in out
+    assert "2 hidden badges" in out
+
+
+def test_me_badges_empty_state(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me/badges")] = {
+        "earned": [], "locked": [], "hidden_locked_count": 0,
+        "total_count": 13,
+    }
+    cli.main(["me", "badges"])
+    assert "no badges yet" in capsys.readouterr().out
+
+
+def test_me_badges_json_passthrough(fake_client, capsys):
+    payload = {"earned": [], "locked": [], "hidden_locked_count": 0,
+               "total_count": 13}
+    fake_client.responses[("GET", "/api/me/badges")] = payload
+    rc = cli.main(["--json", "me", "badges"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == payload
+
+
+def test_me_tz_get_prints_current(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me")] = {
+        "name": "alice", "is_admin": False, "tz": "America/Los_Angeles",
+    }
+    rc = cli.main(["me", "tz"])
+    assert rc == 0
+    assert "America/Los_Angeles" in capsys.readouterr().out
+
+
+def test_me_tz_get_defaults_to_utc(fake_client, capsys):
+    fake_client.responses[("GET", "/api/me")] = {
+        "name": "alice", "is_admin": False, "tz": "",
+    }
+    cli.main(["me", "tz"])
+    assert capsys.readouterr().out.strip() == "UTC"
+
+
+def test_me_tz_set_patches_endpoint(fake_client, capsys):
+    fake_client.responses[("PATCH", "/api/me/tz")] = {
+        "status": "ok", "tz": "Europe/Berlin",
+    }
+    rc = cli.main(["me", "tz", "Europe/Berlin"])
+    assert rc == 0
+    method, path, _, body = fake_client.calls[-1]
+    assert method == "PATCH" and path == "/api/me/tz"
+    assert body == {"tz": "Europe/Berlin"}
+    assert "Europe/Berlin" in capsys.readouterr().out

--- a/VegaNotes/tools/vn/vn/cli.py
+++ b/VegaNotes/tools/vn/vn/cli.py
@@ -444,6 +444,165 @@ def cmd_whoami(client: Client, args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# `vn me <subcommand>` — gamification surface (Phase 2: stats/streak/history)
+# ---------------------------------------------------------------------------
+#
+# Every endpoint under /api/me/... is hard-scoped to the authenticated user
+# server-side. The CLI just renders.
+
+_SPARK_BARS = "▁▂▃▄▅▆▇█"
+
+
+def _sparkline(values: list[int]) -> str:
+    if not values:
+        return ""
+    peak = max(values)
+    if peak == 0:
+        return _SPARK_BARS[0] * len(values)
+    return "".join(
+        _SPARK_BARS[min(len(_SPARK_BARS) - 1, (v * (len(_SPARK_BARS) - 1)) // peak)]
+        for v in values
+    )
+
+
+def cmd_me_stats(client: Client, args: argparse.Namespace) -> int:
+    data = client.get("/api/me/stats")
+    if args.json:
+        _print_json(data)
+        return 0
+    tc = data.get("tasks_closed", {})
+    nt = data.get("notes_touched", {})
+    rate = data.get("on_time_eta_rate_30d")
+    rate_str = f"{rate * 100:.0f}% (n={data.get('on_time_sample_30d', 0)})" if rate is not None else "—"
+    print(f"as of {data.get('as_of', '?')} (UTC)")
+    print()
+    print(f"  closed today      {tc.get('today', 0)}")
+    print(f"  closed last 7d    {tc.get('week', 0)}")
+    print(f"  closed last 30d   {tc.get('month', 0)}")
+    print(f"  closed lifetime   {tc.get('lifetime', 0)}")
+    print()
+    print(f"  notes touched 7d  {nt.get('week', 0)}")
+    print(f"  notes touched 30d {nt.get('month', 0)}")
+    print()
+    print(f"  current streak    {data.get('current_streak_days', 0)} day(s) "
+          f"[rest tokens: {data.get('rest_tokens_remaining', 0)}]")
+    print(f"  longest streak    {data.get('longest_streak_days', 0)} day(s)")
+    print(f"  on-time ETA (30d) {rate_str}")
+    fav = data.get("favorite_project_30d") or "—"
+    print(f"  favorite project  {fav}")
+    by_kind = data.get("by_kind") or {}
+    if by_kind:
+        parts = ", ".join(f"{k}: {v}" for k, v in sorted(by_kind.items()))
+        print(f"  by kind           {parts}")
+    return 0
+
+
+def cmd_me_streak(client: Client, args: argparse.Namespace) -> int:
+    data = client.get("/api/me/streak")
+    if args.json:
+        _print_json(data)
+        return 0
+    cur = data.get("current_streak_days", 0)
+    longest = data.get("longest_streak_days", 0)
+    tokens = data.get("rest_tokens_remaining", 0)
+    flame = "🔥" if cur > 0 else "·"
+    print(f"{flame} {cur} day(s)  (longest: {longest}, rest tokens: {tokens})")
+    return 0
+
+
+def cmd_me_history(client: Client, args: argparse.Namespace) -> int:
+    days = max(1, min(365, getattr(args, "days", 30) or 30))
+    data = client.get("/api/me/history", days=days)
+    if args.json:
+        _print_json(data)
+        return 0
+    closes = [int(d.get("closes", 0)) for d in data]
+    edits = [int(d.get("edits", 0)) for d in data]
+    if not closes:
+        print("(no activity)")
+        return 0
+    print(f"closes  {_sparkline(closes)}  total {sum(closes)}")
+    print(f"edits   {_sparkline(edits)}  total {sum(edits)}")
+    print(f"        {data[0]['date']} … {data[-1]['date']}  ({len(data)}d)")
+    return 0
+
+
+def cmd_me_activity(client: Client, args: argparse.Namespace) -> int:
+    params: dict[str, Any] = {}
+    if getattr(args, "since", None):
+        params["since"] = args.since
+    if getattr(args, "until", None):
+        params["until"] = args.until
+    if getattr(args, "kind", None):
+        params["kind"] = args.kind
+    if getattr(args, "limit", None):
+        params["limit"] = args.limit
+    data = client.get("/api/me/activity", **params)
+    if args.json:
+        _print_json(data)
+        return 0
+    if not data:
+        print("(no events)")
+        return 0
+    for ev in data:
+        meta = ev.get("meta") or {}
+        meta_str = " " + json.dumps(meta, sort_keys=True) if meta else ""
+        print(f"{ev.get('ts', '')}  {ev.get('kind', ''):<18}  {ev.get('ref', '')}{meta_str}")
+    return 0
+
+
+def cmd_me_badges(client: Client, args: argparse.Namespace) -> int:
+    """List earned badges, plus locked badges with progress hints.
+
+    Hidden badges are only shown after they're earned; until then we
+    just print a single "+N hidden" line so users know more exist
+    without spoiling the catalog.
+    """
+    data = client.get("/api/me/badges")
+    if args.json:
+        _print_json(data)
+        return 0
+    earned = data.get("earned", [])
+    locked = data.get("locked", [])
+    hidden = int(data.get("hidden_locked_count", 0))
+    if not earned and not locked and not hidden:
+        print("(no badges yet — close some tasks!)")
+        return 0
+    if earned:
+        print(f"earned ({len(earned)}/{data.get('total_count', '?')}):")
+        for b in earned:
+            print(f"  ★ {b['title']:<18}  {b['description']}")
+    if args.all and locked:
+        print("\nlocked:")
+        for b in locked:
+            prog = f"  [{b['progress']}]" if b.get("progress") else ""
+            print(f"  · {b['title']:<18}  {b['description']}{prog}")
+    if args.all and hidden:
+        print(f"\n+ {hidden} hidden badge{'s' if hidden != 1 else ''} (earn to reveal)")
+    elif not args.all and (locked or hidden):
+        rem = len(locked) + hidden
+        print(f"\n({rem} more to unlock — `vn me badges --all` for hints)")
+    return 0
+
+
+def cmd_me_tz(client: Client, args: argparse.Namespace) -> int:
+    """Get or set the calling user's IANA timezone.
+
+    No argument → print current. With argument → PATCH and confirm.
+    Empty string clears (UTC). Validation happens server-side.
+    """
+    zone = getattr(args, "zone", None)
+    if zone is None:
+        me = client.get("/api/me")
+        print(me.get("tz") or "UTC")
+        return 0
+    body = {"tz": zone}
+    res = client.patch("/api/me/tz", body)
+    print(f"timezone set to {res.get('tz', zone)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # `vn show <resource>` — read-only inspector for the rest of the API.
 # ---------------------------------------------------------------------------
 #
@@ -912,6 +1071,52 @@ def build_parser() -> argparse.ArgumentParser:
 
     pw = sub.add_parser("whoami", help="show authenticated user")
     pw.set_defaults(func=cmd_whoami)
+
+    # `vn me <subcommand>` — gamification surface (Phase 2: read-only).
+    pme = sub.add_parser(
+        "me",
+        help="personal stats / streak / activity (gamification)",
+        description=(
+            "Solo / self-progress mode: stats are visible only to you.\n\n"
+            "Examples:\n"
+            "  vn me stats                  # full stats card\n"
+            "  vn me streak                 # current + longest streak\n"
+            "  vn me history --days 30      # ANSI sparkline of closes/edits\n"
+            "  vn me activity --kind task.closed --limit 20\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    me_sub = pme.add_subparsers(dest="me_command", required=True)
+
+    pms = me_sub.add_parser("stats", help="full personal stats card")
+    pms.set_defaults(func=cmd_me_stats)
+
+    pmr = me_sub.add_parser("streak", help="current + longest streak")
+    pmr.set_defaults(func=cmd_me_streak)
+
+    pmh = me_sub.add_parser("history", help="per-day close/edit sparkline")
+    pmh.add_argument("--days", type=int, default=30,
+                     help="trailing window in days (1..365, default 30)")
+    pmh.set_defaults(func=cmd_me_history)
+
+    pma = me_sub.add_parser("activity", help="recent activity event log")
+    pma.add_argument("--since", help="ISO date (YYYY-MM-DD); inclusive")
+    pma.add_argument("--until", help="ISO date (YYYY-MM-DD); exclusive")
+    pma.add_argument("--kind", help="filter by event kind (e.g. task.closed)")
+    pma.add_argument("--limit", type=int, default=50,
+                     help="cap on rows returned (1..1000, default 50)")
+    pma.set_defaults(func=cmd_me_activity)
+
+    pmb = me_sub.add_parser("badges", help="earned badges + locked progress")
+    pmb.add_argument("--all", action="store_true",
+                     help="also list locked badges with progress hints")
+    pmb.set_defaults(func=cmd_me_badges)
+
+    pmt = me_sub.add_parser("tz", help="get or set your IANA timezone")
+    pmt.add_argument("zone", nargs="?",
+                     help="IANA name (e.g. America/Los_Angeles); omit to read; "
+                          "empty string clears (UTC)")
+    pmt.set_defaults(func=cmd_me_tz)
 
     # `vn show <resource> [target]` — read-only inspector for the rest of
     # the API; reuses --format / --columns where it makes sense.


### PR DESCRIPTION
Closes #132. Stacks on #131 (review/merge after).

13-badge curated catalog + per-user IANA TZ for streak/history bucketing. Awards run at end of every record_event() and are idempotent via UNIQUE index. Hidden badges roll into a footer count until earned.

Backend 194/194; vn 188/188.