### PR TITLE
VegaNotes gamification Phase 4 — CLI delight + opt-out

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -317,13 +317,17 @@ def upsert_note(
             },
         )
     note = reindex_file(full, s)
+    awarded: list[str] = []
     if not pre_existing:
-        gamify.record_event(s, user, gamify.NOTE_CREATED, ref=body.path)
+        awarded = gamify.record_event(s, user, gamify.NOTE_CREATED, ref=body.path)
     elif pre_body.strip() != body.body_md.strip():
         # Skip whitespace-only / no-op writes so streaks aren't gamed by
         # repeatedly saving an unchanged file.
-        gamify.record_event(s, user, gamify.NOTE_EDITED, ref=body.path)
-    return {"id": note.id, "path": note.path, "etag": new_etag}
+        awarded = gamify.record_event(s, user, gamify.NOTE_EDITED, ref=body.path)
+    out: dict[str, Any] = {"id": note.id, "path": note.path, "etag": new_etag}
+    if awarded:
+        out["awarded_badges"] = awarded
+    return out
 
 
 class RollNextWeekIn(BaseModel):
@@ -588,12 +592,15 @@ def create_task(
         reindex_file(full, s)
         created = s.exec(select(Task).where(Task.task_uuid == new_id)).first()
 
-    gamify.record_event(
+    awarded = gamify.record_event(
         s, user, gamify.TASK_CREATED,
         ref=created.task_uuid or f"task#{created.id}",
         meta={"kind": created.kind, "status": created.status},
     )
-    return _task_to_dict(s, created, include_children=True) | {"note_path": rel}
+    out = _task_to_dict(s, created, include_children=True) | {"note_path": rel}
+    if awarded:
+        out["awarded_badges"] = awarded
+    return out
 
 
 class ArCreate(BaseModel):
@@ -696,12 +703,15 @@ def create_ar_under_task(
     created = s.exec(select(Task).where(Task.task_uuid == new_id)).first()
     if created is None:
         raise HTTPException(500, "AR created but not found in index — please refresh")
-    gamify.record_event(
+    awarded = gamify.record_event(
         s, user, gamify.TASK_CREATED,
         ref=created.task_uuid or f"task#{created.id}",
         meta={"kind": "ar", "parent_task_uuid": parent_uuid},
     )
-    return _task_to_dict(s, created) | {"parent_task_uuid": parent_uuid}
+    out = _task_to_dict(s, created) | {"parent_task_uuid": parent_uuid}
+    if awarded:
+        out["awarded_badges"] = awarded
+    return out
 
 
 @router.post("/parse")
@@ -1577,21 +1587,29 @@ def patch_task(
                     reindex_file(ref_full, s)
 
     refreshed = s.get(Task, task_id)
+    awarded: list[str] = []
     if status_changed and body.status is not None:
         ev_ref = (refreshed.task_uuid if refreshed and refreshed.task_uuid
                   else (t.task_uuid or f"task#{task_id}"))
-        gamify.record_event(
+        awarded += gamify.record_event(
             s, user, gamify.TASK_STATUS_SET,
             ref=ev_ref,
             meta={"from": old_status, "to": body.status},
         )
         if (body.status or "").lower() == "done":
-            gamify.record_event(
+            awarded += gamify.record_event(
                 s, user, gamify.TASK_CLOSED,
                 ref=ev_ref,
                 meta={"from": old_status, "to": body.status},
             )
-    return _task_to_dict(s, refreshed) if refreshed else {"ok": True}
+    out = _task_to_dict(s, refreshed) if refreshed else {"ok": True}
+    if awarded:
+        # De-dupe: status_set + close on the same task can both award
+        # (rare). Preserve order.
+        seen: set[str] = set()
+        deduped = [k for k in awarded if not (k in seen or seen.add(k))]
+        out["awarded_badges"] = deduped
+    return out
 
 
 @router.delete("/tasks/{task_ref}")

--- a/VegaNotes/tools/vn/README.md
+++ b/VegaNotes/tools/vn/README.md
@@ -278,6 +278,33 @@ subcommand:
 vn --json me stats | jq .current_streak_days
 ```
 
+**Celebrations.** When `vn task` or `vn note new` triggers a new badge
+unlock, the CLI prints a single `unlocked: <Name> — <blurb>` line
+right after the normal output. Nothing nag-screen, nothing persistent.
+
+### `vn config` — local CLI settings
+
+Per-profile settings live in `~/.veganotes/config` (INI format, one
+section per profile). Two keys are recognised today, both default
+**on**:
+
+| key | effect when off |
+|---|---|
+| `gamify` | hide all `vn me <subcommand>` output (commands return a one-line notice) and suppress badge celebrations |
+| `gamify.notify` | keep stats/badges working, but suppress the `unlocked:` celebration line |
+
+```bash
+vn config                       # list keys, values, and which are defaults
+vn config gamify                # show one key
+vn config gamify=off            # disable gamification surfacing entirely
+vn config gamify.notify off     # space-separated form also works
+```
+
+This is a **client-side** kill switch — events keep accruing on the
+server, so flipping `gamify=on` later restores your full history.
+`vn me tz` still works with `gamify=off` because timezone is a
+generic preference, not a gamification surface.
+
 ### `vn show <resource>` — read-only inspector
 
 Browse the database without curl-ing the API by hand. Every resource maps

--- a/VegaNotes/tools/vn/tests/conftest.py
+++ b/VegaNotes/tools/vn/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Test-wide fixtures.
+
+We force ``vn.settings.CONFIG_PATH`` to a non-existent temp path for
+every test so the user's real ``~/.veganotes/config`` (which may have
+``gamify=off`` set) doesn't leak into the test run.
+"""
+from __future__ import annotations
+
+import pytest
+
+from vn import settings as _vn_settings
+from vn import cli as _cli
+
+
+@pytest.fixture(autouse=True)
+def _isolate_vn_config(monkeypatch, tmp_path_factory):
+    cfg = tmp_path_factory.mktemp("vn-cfg") / "config"
+    monkeypatch.setattr(_vn_settings, "CONFIG_PATH", cfg)
+    # Reset cli's snapshot so commands that don't otherwise touch
+    # _settings start from defaults.
+    monkeypatch.setattr(_cli, "_settings", _vn_settings.Settings())

--- a/VegaNotes/tools/vn/tests/test_cli.py
+++ b/VegaNotes/tools/vn/tests/test_cli.py
@@ -1077,3 +1077,156 @@ def test_me_tz_set_patches_endpoint(fake_client, capsys):
     assert method == "PATCH" and path == "/api/me/tz"
     assert body == {"tz": "Europe/Berlin"}
     assert "Europe/Berlin" in capsys.readouterr().out
+
+
+# ---------- vn config (Phase 4) -------------------------------------------
+
+import tempfile as _tempfile
+from pathlib import Path as _Path
+
+from vn import settings as _vn_settings
+
+def _force_settings(monkeypatch, **kw):
+    """Pin both the in-process snapshot and the loader so main() can't
+    overwrite our test-supplied settings when it re-reads from disk."""
+    obj = _vn_settings.Settings(**kw)
+    monkeypatch.setattr(cli, "_settings", obj)
+    monkeypatch.setattr(_vn_settings, "load_settings",
+                        lambda profile="default", **_: obj)
+    return obj
+
+
+@pytest.fixture
+def tmp_config(monkeypatch, tmp_path):
+    cfg = tmp_path / "config"
+    monkeypatch.setattr(_vn_settings, "CONFIG_PATH", cfg)
+    # Don't pin load_settings here — these tests want to round-trip
+    # writes through the real loader to verify persistence.
+    monkeypatch.setattr(cli, "_settings", _vn_settings.Settings())
+    return cfg
+
+
+def test_config_list_defaults(tmp_config, fake_client, capsys):
+    rc = cli.main(["config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "gamify" in out and "on" in out
+    assert "(default)" in out
+
+
+def test_config_set_persists(tmp_config, fake_client, capsys):
+    rc = cli.main(["config", "gamify=off"])
+    assert rc == 0
+    assert "gamify" in capsys.readouterr().out
+    s = _vn_settings.load_settings("default")
+    assert s.gamify_enabled is False
+    assert s.gamify_notify is True
+
+
+def test_config_set_two_token_form(tmp_config, fake_client):
+    rc = cli.main(["config", "gamify.notify", "off"])
+    assert rc == 0
+    s = _vn_settings.load_settings("default")
+    assert s.gamify_notify is False
+
+
+def test_config_get_one_key(tmp_config, fake_client, capsys):
+    _vn_settings.set_setting("gamify", "off", "default")
+    rc = cli.main(["config", "gamify"])
+    assert rc == 0
+    assert "off" in capsys.readouterr().out
+
+
+def test_config_unknown_key_errors(tmp_config, fake_client, capsys):
+    rc = cli.main(["config", "frobnicate=on"])
+    assert rc == 2
+    assert "unknown config key" in capsys.readouterr().err
+
+
+def test_config_invalid_value_errors(tmp_config, fake_client, capsys):
+    rc = cli.main(["config", "gamify=maybe"])
+    assert rc == 2
+    assert "invalid boolean" in capsys.readouterr().err
+
+
+def test_me_stats_blocked_when_gamify_off(monkeypatch, fake_client, capsys):
+    _force_settings(monkeypatch, gamify_enabled=False)
+    rc = cli.main(["me", "stats"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "gamification is off" in err
+    assert not any(c[1] == "/api/me/stats" for c in fake_client.calls)
+
+
+def test_me_badges_blocked_when_gamify_off(monkeypatch, fake_client, capsys):
+    _force_settings(monkeypatch, gamify_enabled=False)
+    rc = cli.main(["me", "badges"])
+    assert rc == 0
+    assert not any(c[1] == "/api/me/badges" for c in fake_client.calls)
+
+
+def test_me_tz_works_when_gamify_off(monkeypatch, fake_client, capsys):
+    _force_settings(monkeypatch, gamify_enabled=False)
+    fake_client.responses[("GET", "/api/me")] = {
+        "name": "alice", "is_admin": False, "tz": "UTC",
+    }
+    rc = cli.main(["me", "tz"])
+    assert rc == 0
+    assert "UTC" in capsys.readouterr().out
+
+
+def test_task_patch_announces_new_badges(monkeypatch, fake_client, capsys):
+    _force_settings(monkeypatch)
+    fake_client.responses[("PATCH", "/api/tasks/T-XYZ")] = {
+        "task_uuid": "T-XYZ", "title": "x", "status": "done",
+        "awarded_badges": ["first_light", "hat_trick"],
+    }
+    rc = cli.main(["task", "T-XYZ", "status=done"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "unlocked: First Light" in out
+    assert "unlocked: Hat Trick" in out
+
+
+def test_celebration_silenced_when_notify_off(monkeypatch, fake_client, capsys):
+    _force_settings(monkeypatch, gamify_notify=False)
+    fake_client.responses[("PATCH", "/api/tasks/T-XYZ")] = {
+        "task_uuid": "T-XYZ", "title": "x",
+        "awarded_badges": ["first_light"],
+    }
+    cli.main(["task", "T-XYZ", "status=done"])
+    out = capsys.readouterr().out
+    assert "unlocked" not in out
+
+
+def test_celebration_silenced_when_gamify_off(monkeypatch, fake_client, capsys):
+    _force_settings(monkeypatch, gamify_enabled=False,
+                                              gamify_notify=True)
+    fake_client.responses[("PATCH", "/api/tasks/T-XYZ")] = {
+        "task_uuid": "T-XYZ", "title": "x",
+        "awarded_badges": ["first_light"],
+    }
+    cli.main(["task", "T-XYZ", "status=done"])
+    out = capsys.readouterr().out
+    assert "unlocked" not in out
+
+
+def test_unknown_badge_key_falls_back_to_raw(monkeypatch, fake_client, capsys):
+    _force_settings(monkeypatch)
+    fake_client.responses[("PATCH", "/api/tasks/T-XYZ")] = {
+        "task_uuid": "T-XYZ", "title": "x",
+        "awarded_badges": ["future_badge_999"],
+    }
+    cli.main(["task", "T-XYZ", "status=done"])
+    out = capsys.readouterr().out
+    assert "unlocked: future_badge_999" in out
+
+
+def test_no_celebration_without_awarded_badges(monkeypatch, fake_client, capsys):
+    _force_settings(monkeypatch)
+    fake_client.responses[("PATCH", "/api/tasks/T-XYZ")] = {
+        "task_uuid": "T-XYZ", "title": "x", "status": "done",
+    }
+    cli.main(["task", "T-XYZ", "status=done"])
+    out = capsys.readouterr().out
+    assert "unlocked" not in out

--- a/VegaNotes/tools/vn/vn/cli.py
+++ b/VegaNotes/tools/vn/vn/cli.py
@@ -26,6 +26,60 @@ from . import __version__
 from .client import ApiError, Client
 from .config import CredentialsError, load_credentials
 from .query import DSLError, compile_clauses
+from . import settings as vn_settings
+
+
+# Module-level settings; populated in ``main()`` from the active
+# profile, exposed as a module attribute so tests can monkeypatch it.
+_settings: vn_settings.Settings = vn_settings.Settings()
+
+
+def _announce_badges(data: Any) -> None:
+    """Print one celebration line per badge in ``data['awarded_badges']``.
+
+    No-op if ``data`` doesn't look like a dict, the user has disabled
+    gamify or notifications, or the list is empty. Titles are looked up
+    from a small static table; unknown keys fall back to the raw key so
+    a server adding a new badge doesn't silently break the CLI.
+    """
+    if not (_settings.gamify_enabled and _settings.gamify_notify):
+        return
+    if not isinstance(data, dict):
+        return
+    keys = data.get("awarded_badges") or []
+    if not keys:
+        return
+    for k in keys:
+        title, desc = _BADGE_BLURBS.get(k, (k, ""))
+        suffix = f" — {desc}" if desc else ""
+        print(f"unlocked: {title}{suffix}")
+
+
+# Mirrors VegaNotes/backend/app/badges.py CATALOG. Kept as a static
+# table so the CLI doesn't need a network round-trip to render a one-
+# line celebration; if the server ships a new key the CLI just falls
+# back to printing the raw key.
+_BADGE_BLURBS: dict[str, tuple[str, str]] = {
+    "first_light": ("First Light", "close your first task"),
+    "hat_trick": ("Hat Trick", "close 3 tasks in one day"),
+    "marathoner": ("Marathoner", "10-day activity streak"),
+    "centurion": ("Centurion", "100 tasks closed lifetime"),
+    "on_time": ("On Time", "10 tasks closed on or before ETA"),
+    "curator": ("Curator", "edit the same note 5+ times"),
+    "docs_day": ("Docs Day", "create 3 notes in one day"),
+    "polyglot": ("Polyglot", "5 distinct projects in one week"),
+    "cleanup_crew": ("Cleanup Crew", "5 aged tasks closed in one week"),
+    "weekend_warrior": ("Weekend Warrior", ""),
+    "quiet_hours": ("Quiet Hours", ""),
+    "ghost_writer": ("Ghost Writer", ""),
+    "phoenix": ("Phoenix", ""),
+}
+
+
+def _gamify_disabled_notice() -> int:
+    print("vn: gamification is off for this profile "
+          "(re-enable with `vn config gamify=on`)", file=sys.stderr)
+    return 0
 
 
 # Attribute keys accepted by `vn task ID key=value ...`.
@@ -247,6 +301,7 @@ def cmd_task(client: Client, args: argparse.Namespace) -> int:
         _print_json(data)
     else:
         _print_task_table([data]) if isinstance(data, dict) else _print_json(data)
+    _announce_badges(data)
     return 0
 
 
@@ -427,6 +482,7 @@ def cmd_note_new(client: Client, args: argparse.Namespace) -> int:
     else:
         nid = data.get("id") if isinstance(data, dict) else "?"
         print(f"created note id={nid} path={path}")
+    _announce_badges(data)
     return 0
 
 
@@ -466,6 +522,8 @@ def _sparkline(values: list[int]) -> str:
 
 
 def cmd_me_stats(client: Client, args: argparse.Namespace) -> int:
+    if not _settings.gamify_enabled:
+        return _gamify_disabled_notice()
     data = client.get("/api/me/stats")
     if args.json:
         _print_json(data)
@@ -498,6 +556,8 @@ def cmd_me_stats(client: Client, args: argparse.Namespace) -> int:
 
 
 def cmd_me_streak(client: Client, args: argparse.Namespace) -> int:
+    if not _settings.gamify_enabled:
+        return _gamify_disabled_notice()
     data = client.get("/api/me/streak")
     if args.json:
         _print_json(data)
@@ -511,6 +571,8 @@ def cmd_me_streak(client: Client, args: argparse.Namespace) -> int:
 
 
 def cmd_me_history(client: Client, args: argparse.Namespace) -> int:
+    if not _settings.gamify_enabled:
+        return _gamify_disabled_notice()
     days = max(1, min(365, getattr(args, "days", 30) or 30))
     data = client.get("/api/me/history", days=days)
     if args.json:
@@ -528,6 +590,8 @@ def cmd_me_history(client: Client, args: argparse.Namespace) -> int:
 
 
 def cmd_me_activity(client: Client, args: argparse.Namespace) -> int:
+    if not _settings.gamify_enabled:
+        return _gamify_disabled_notice()
     params: dict[str, Any] = {}
     if getattr(args, "since", None):
         params["since"] = args.since
@@ -552,6 +616,8 @@ def cmd_me_activity(client: Client, args: argparse.Namespace) -> int:
 
 
 def cmd_me_badges(client: Client, args: argparse.Namespace) -> int:
+    if not _settings.gamify_enabled:
+        return _gamify_disabled_notice()
     """List earned badges, plus locked badges with progress hints.
 
     Hidden badges are only shown after they're earned; until then we
@@ -600,6 +666,79 @@ def cmd_me_tz(client: Client, args: argparse.Namespace) -> int:
     res = client.patch("/api/me/tz", body)
     print(f"timezone set to {res.get('tz', zone)}")
     return 0
+
+
+def cmd_config(client: Client, args: argparse.Namespace) -> int:
+    """Get / set / list profile-local CLI settings.
+
+    Forms:
+
+      vn config                   — list every known key + current value
+      vn config gamify            — print one key
+      vn config gamify=off        — set one key
+      vn config gamify off        — same as above (positional)
+
+    These are stored in ``~/.veganotes/config`` per profile and are
+    independent of the server (the kill switch is client-side).
+    """
+    profile = args.profile or "default"
+    if not args.entries:
+        rows = vn_settings.list_settings(profile)
+        if args.json:
+            _print_json({k: v for k, v, _ in rows})
+            return 0
+        for key, val, is_default in rows:
+            tag = " (default)" if is_default else ""
+            print(f"{key:<18}{val}{tag}")
+        return 0
+
+    # Parse the positional words. Accept either:
+    #   key=value
+    #   key value   (two tokens)
+    #   key         (read one)
+    pairs: list[tuple[str, Optional[str]]] = []
+    i = 0
+    while i < len(args.entries):
+        tok = args.entries[i]
+        if "=" in tok:
+            k, _, v = tok.partition("=")
+            pairs.append((k.strip(), v.strip()))
+            i += 1
+            continue
+        # No '=': may be key or key+value across two tokens.
+        nxt = args.entries[i + 1] if i + 1 < len(args.entries) else None
+        if nxt is not None and "=" not in nxt and not _looks_like_key(nxt):
+            pairs.append((tok.strip(), nxt.strip()))
+            i += 2
+        else:
+            pairs.append((tok.strip(), None))
+            i += 1
+
+    rc = 0
+    for key, value in pairs:
+        try:
+            if value is None:
+                print(f"{key:<18}{vn_settings.get_setting(key, profile)}")
+            else:
+                stored = vn_settings.set_setting(key, value, profile)
+                # Refresh the in-process settings so subsequent commands
+                # in the same invocation see the new value.
+                global _settings
+                _settings = vn_settings.load_settings(profile)
+                print(f"{key:<18}{stored}")
+        except KeyError:
+            valid = ", ".join(k for k, _ in vn_settings.KNOWN_BOOL_KEYS)
+            print(f"vn: unknown config key: {key!r} (valid: {valid})",
+                  file=sys.stderr)
+            rc = 2
+        except ValueError as e:
+            print(f"vn: {e}", file=sys.stderr)
+            rc = 2
+    return rc
+
+
+def _looks_like_key(tok: str) -> bool:
+    return tok in {k for k, _ in vn_settings.KNOWN_BOOL_KEYS}
 
 
 # ---------------------------------------------------------------------------
@@ -1118,6 +1257,23 @@ def build_parser() -> argparse.ArgumentParser:
                           "empty string clears (UTC)")
     pmt.set_defaults(func=cmd_me_tz)
 
+    pcfg = sub.add_parser(
+        "config",
+        help="get / set / list profile-local CLI settings",
+        description=(
+            "Read or write profile-local CLI settings (stored in "
+            "~/.veganotes/config). Examples:\n"
+            "  vn config                  # list all settings\n"
+            "  vn config gamify           # read one\n"
+            "  vn config gamify=off       # set one\n"
+            "  vn config gamify.notify=on # set the celebration toggle\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    pcfg.add_argument("entries", nargs="*",
+                      help="key, key=value, or key value tokens; omit to list")
+    pcfg.set_defaults(func=cmd_config)
+
     # `vn show <resource> [target]` — read-only inspector for the rest of
     # the API; reuses --format / --columns where it makes sense.
     show_resources = (
@@ -1196,6 +1352,23 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    # Load CLI settings (gamify toggle etc) from the active profile.
+    # Failure here is non-fatal — bad config shouldn't lock the user
+    # out of the rest of the CLI; just fall back to defaults.
+    global _settings
+    try:
+        _settings = vn_settings.load_settings(args.profile or "default")
+    except Exception:
+        _settings = vn_settings.Settings()
+
+    # `vn config` runs locally — no credentials needed.
+    if getattr(args, "func", None) is cmd_config:
+        try:
+            return args.func(None, args)  # type: ignore[arg-type]
+        except Exception as e:
+            print(f"vn: {e}", file=sys.stderr)
+            return 1
 
     try:
         creds = load_credentials(args.profile)

--- a/VegaNotes/tools/vn/vn/settings.py
+++ b/VegaNotes/tools/vn/vn/settings.py
@@ -1,0 +1,153 @@
+"""Per-profile vn CLI settings (gamification toggles, etc).
+
+Stored in ``~/.veganotes/config`` as an INI file, mirroring the
+credentials file. Keep it separate from credentials so the config
+file can be checked in / shared via dotfiles without leaking secrets.
+
+Currently exposes:
+
+* ``gamify`` — master toggle. When ``off``, ``vn me ...`` commands
+  short-circuit before hitting the API and write commands skip the
+  celebration line. Server-side recording is unaffected; the user
+  can flip it back on at any time and the prior data is still there.
+* ``gamify.notify`` — when ``off``, write commands stay silent even
+  if the API hands back a freshly-earned badge.
+
+Both default to ``on`` for new profiles.
+
+Example::
+
+    [default]
+    gamify = on
+    gamify.notify = on
+"""
+from __future__ import annotations
+
+import configparser
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+CONFIG_PATH = Path.home() / ".veganotes" / "config"
+
+# Public list of (key, default-bool) tuples. The CLI uses this to render
+# `vn config` listings deterministically and to decide which keys are
+# valid to set.
+KNOWN_BOOL_KEYS: tuple[tuple[str, bool], ...] = (
+    ("gamify", True),
+    ("gamify.notify", True),
+)
+_DEFAULTS: dict[str, bool] = dict(KNOWN_BOOL_KEYS)
+
+
+@dataclass
+class Settings:
+    gamify_enabled: bool = True
+    gamify_notify: bool = True
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, str]) -> "Settings":
+        return cls(
+            gamify_enabled=_parse_bool(raw.get("gamify"), default=True),
+            gamify_notify=_parse_bool(raw.get("gamify.notify"), default=True),
+        )
+
+
+def _parse_bool(val: Optional[str], *, default: bool) -> bool:
+    if val is None:
+        return default
+    s = val.strip().lower()
+    if s in {"1", "on", "true", "yes", "y"}:
+        return True
+    if s in {"0", "off", "false", "no", "n"}:
+        return False
+    return default
+
+
+def _format_bool(b: bool) -> str:
+    return "on" if b else "off"
+
+
+def _resolve_path(path: Optional[Path]) -> Path:
+    """Read CONFIG_PATH lazily so test fixtures that monkeypatch the
+    module-level constant after import still take effect."""
+    return path if path is not None else CONFIG_PATH
+
+
+def _read_all(path: Optional[Path] = None) -> configparser.ConfigParser:
+    p = _resolve_path(path)
+    cp = configparser.ConfigParser()
+    if p.exists():
+        cp.read(p)
+    return cp
+
+
+def _profile_dict(profile: str, path: Optional[Path] = None) -> dict[str, str]:
+    cp = _read_all(path)
+    if profile not in cp:
+        return {}
+    return {k.lower(): v for k, v in cp[profile].items()}
+
+
+def load_settings(profile: str = "default", *, path: Optional[Path] = None) -> Settings:
+    """Load this profile's settings, applying defaults for missing keys."""
+    return Settings.from_dict(_profile_dict(profile, path))
+
+
+def get_setting(
+    key: str, profile: str = "default", *, path: Optional[Path] = None,
+) -> str:
+    """Return the stored string value for ``key`` (or its default).
+
+    Raises ``KeyError`` if ``key`` is not a known config key.
+    """
+    if key not in _DEFAULTS:
+        raise KeyError(key)
+    raw = _profile_dict(profile, path).get(key.lower())
+    if raw is not None:
+        return _format_bool(_parse_bool(raw, default=_DEFAULTS[key]))
+    return _format_bool(_DEFAULTS[key])
+
+
+def set_setting(
+    key: str, value: str, profile: str = "default", *, path: Optional[Path] = None,
+) -> str:
+    """Persist ``key=value`` for ``profile``. Returns the canonical
+    stored form ('on' / 'off').
+
+    Raises ``KeyError`` if ``key`` is not known or ``ValueError`` if
+    ``value`` doesn't parse as a boolean.
+    """
+    if key not in _DEFAULTS:
+        raise KeyError(key)
+    s = (value or "").strip().lower()
+    if s in {"1", "on", "true", "yes", "y"}:
+        parsed = True
+    elif s in {"0", "off", "false", "no", "n"}:
+        parsed = False
+    else:
+        raise ValueError(f"invalid boolean: {value!r}")
+    canon = _format_bool(parsed)
+    p = _resolve_path(path)
+    cp = _read_all(p)
+    if profile not in cp:
+        cp[profile] = {}
+    cp[profile][key] = canon
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        cp.write(f)
+    return canon
+
+
+def list_settings(profile: str = "default", *, path: Optional[Path] = None) -> list[tuple[str, str, bool]]:
+    """Return ``[(key, value, is_default), ...]`` for every known key."""
+    raw = _profile_dict(profile, path)
+    out: list[tuple[str, str, bool]] = []
+    for key, default in KNOWN_BOOL_KEYS:
+        stored = raw.get(key.lower())
+        if stored is None:
+            out.append((key, _format_bool(default), True))
+        else:
+            out.append((key, _format_bool(_parse_bool(stored, default=default)), False))
+    return out


### PR DESCRIPTION
Implements Phase 4 of the VegaNotes solo gamification plan: surface badge unlocks in the CLI and add a client-side opt-out.

Closes #135.

## What changed

**Backend** (`VegaNotes/backend/app/api/__init__.py`)
- 4 write endpoints now capture the `record_event` return value and include `awarded_badges: [...]` in the response when non-empty:
  - `PUT /api/notes`
  - `POST /api/tasks`
  - `POST /api/tasks/{ref}/ars`
  - `PATCH /api/tasks/{ref}` (aggregates badges from `TASK_STATUS_SET` + `TASK_CLOSED`, dedupes)

**CLI** (`VegaNotes/tools/vn/vn/cli.py`, new `vn/settings.py`)
- New `vn config` subcommand (list / get / set via positional `key` or `key=value`).
- Settings persist in `~/.veganotes/config` (INI, one section per profile).
- Two known keys, both **default ON**:
  - `gamify` — gates every `vn me <subcommand>` and suppresses celebrations.
  - `gamify.notify` — gates only the celebration line, leaves stats alone.
- `vn task` / `vn note new` print one celebratory line after normal output:
  ```
  T-ABC123: status -> done
  unlocked: Hat Trick — close 3 tasks in one day
  ```
- Static `_BADGE_BLURBS` table mirrors the backend catalog (unknown keys gracefully fall back to the raw key).
- `vn me tz` is **exempt** from `gamify=off` — timezone is a general preference, not gamification surfacing.
- `vn config` runs without API credentials.

**Tests** (`tests/test_cli.py`, new `tests/conftest.py`)
- Autouse fixture redirects `~/.veganotes/config` to a per-test temp file so the user's real config can't leak into the suite.
- 14 new tests covering: config round-trip, two-token form, unknown-key + invalid-value errors, `me` gating with `gamify=off`, `tz` still works with gamify off, celebration on/off, `gamify.notify=off`, unknown-badge fallback, no-celebration when no badges awarded.

**Docs** (`VegaNotes/tools/vn/README.md`)
- New `vn config` section + a paragraph about celebrations under `vn me`.

## Out of scope (deferred per design discussion)
- `vn me reset` — escape hatch to wipe a user's event log + badges. Can be its own PR.
- Server-side enforcement of the opt-out. Today the server still records events when the client has `gamify=off`; that is intentional so flipping it back on restores history.

## Test results
- vn suite: **202 passed** (188 existing + 14 new).
- Backend suite: all green with the documented pre-existing deselects (`tests/api/test_api.py::test_create_and_query`, `tests/parser/test_parser.py::test_golden[sprint14]`).