### PR TITLE
VegaNotes gamification Phase 5 — frontend Me page

### DIFF
--- a/VegaNotes/README.md
+++ b/VegaNotes/README.md
@@ -47,7 +47,12 @@ helm install veganotes deploy/helm/veganotes
 - **Powerful queries** — per-user task lists, "agenda for next week" sorted by
   ETA then priority, filter-by-feature with cross-user aggregation,
   bidirectional link graph. See [docs/queries.md](docs/queries.md).
-- **Multiple views** — Editor, Kanban, Timeline (Gantt), Calendar, Graph, Agenda.
+- **Multiple views** — Editor, Kanban, Timeline (Gantt), Calendar, Graph, Agenda, Me.
+- **Solo gamification** — every user gets a private "Me" page (and `vn me`
+  in the CLI) with stats, streaks, badges, history sparkline, and recent
+  activity. Closing a task that crosses a badge threshold pops a toast in
+  the web UI; opt out per-client with the toggle on the Me page (or
+  `vn config gamify=off`). No leaderboards, no cross-user comparisons.
 
 ## Documentation
 - [Syntax](docs/syntax.md) · [Queries](docs/queries.md) · [Architecture](docs/architecture.md)

--- a/VegaNotes/frontend/package.json
+++ b/VegaNotes/frontend/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.2.1",
     "autoprefixer": "^10.4.19",
+    "jsdom": "^29.1.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.0",

--- a/VegaNotes/frontend/src/App.tsx
+++ b/VegaNotes/frontend/src/App.tsx
@@ -7,6 +7,8 @@ import { TimelineView } from "./components/Timeline/TimelineView";
 import { CalendarView } from "./components/Calendar/CalendarView";
 import { GraphView } from "./components/Graph/GraphView";
 import { MyTasksView } from "./components/Tasks/MyTasksView";
+import { MeView } from "./components/Me/MeView";
+import { UnlockToast } from "./components/Me/UnlockToast";
 import { CommandPalette } from "./components/CommandPalette/CommandPalette";
 import { NoteEditor } from "./components/Editor/NoteEditor";
 import { Sidebar } from "./components/Sidebar/Sidebar";
@@ -31,6 +33,7 @@ function ViewSwitcher({ selectedPath, setSelectedPath, draft, setDraft }: {
     case "graph":     return <GraphView />;
     case "admin":     return <AdminPanel />;
     case "my-tasks":  return <MyTasksView />;
+    case "me":        return <MeView />;
     case "editor":    return <EditorPane selectedPath={selectedPath} setSelectedPath={setSelectedPath} draft={draft} setDraft={setDraft} />;
   }
 }
@@ -475,8 +478,8 @@ function NavBar() {
   const { view, set } = useUI();
   const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
   const [changingPw, setChangingPw] = useState(false);
-  const tabs: ("editor" | "kanban" | "agenda" | "timeline" | "calendar" | "graph" | "admin" | "my-tasks")[] = [
-    "my-tasks", "editor", "kanban", "agenda", "timeline", "calendar", "graph",
+  const tabs: ("editor" | "kanban" | "agenda" | "timeline" | "calendar" | "graph" | "admin" | "my-tasks" | "me")[] = [
+    "my-tasks", "editor", "kanban", "agenda", "timeline", "calendar", "graph", "me",
   ];
   if (me?.is_admin) tabs.push("admin");
 
@@ -569,6 +572,7 @@ export default function App() {
           </main>
         </div>
         <CommandPalette />
+        <UnlockToast />
       </div>
     </QueryClientProvider>
   );

--- a/VegaNotes/frontend/src/api/client.ts
+++ b/VegaNotes/frontend/src/api/client.ts
@@ -66,7 +66,36 @@ export class ApiError extends Error {
   }
 }
 
+/** Listeners registered via {@link onAwardedBadges}. Fired once per write
+ * response that carries a non-empty `awarded_badges` array. */
+type BadgeListener = (badges: string[]) => void;
+const _badgeListeners = new Set<BadgeListener>();
+
+/** Subscribe to "badge unlocked" events emitted by any write request.
+ *
+ * Returns an unsubscribe function. Used by the `<UnlockToast>` component
+ * to surface server-awarded badges immediately after the action that
+ * earned them, with no per-call-site wiring.
+ */
+export function onAwardedBadges(fn: BadgeListener): () => void {
+  _badgeListeners.add(fn);
+  return () => _badgeListeners.delete(fn);
+}
+
+function _maybeFireBadges(method: string, body: unknown) {
+  if (method === "GET") return;
+  if (!body || typeof body !== "object") return;
+  const arr = (body as { awarded_badges?: unknown }).awarded_badges;
+  if (!Array.isArray(arr) || arr.length === 0) return;
+  const keys = arr.filter((k): k is string => typeof k === "string");
+  if (keys.length === 0) return;
+  for (const fn of _badgeListeners) {
+    try { fn(keys); } catch { /* listener errors must not break the request */ }
+  }
+}
+
 async function req<T>(path: string, init?: RequestInit): Promise<T> {
+  const method = (init?.method ?? "GET").toUpperCase();
   const r = await fetch(BASE + path, {
     credentials: "include",
     ...init,
@@ -86,7 +115,9 @@ async function req<T>(path: string, init?: RequestInit): Promise<T> {
     }
     throw new ApiError(r.status, r.statusText, path, detail, body);
   }
-  return r.json() as Promise<T>;
+  const parsed = (await r.json()) as T;
+  _maybeFireBadges(method, parsed);
+  return parsed;
 }
 
 export interface ProjectInfo {
@@ -214,7 +245,7 @@ export const api = {
     }),
 
   users: () => req<string[]>("/users"),
-  me: () => req<{ name: string; is_admin: boolean }>("/me"),
+  me: () => req<{ name: string; is_admin: boolean; tz?: string }>("/me"),
   changeMyPassword: (current_password: string, new_password: string) =>
     req<{ status: string }>("/me/password", {
       method: "PATCH",
@@ -251,4 +282,82 @@ export const api = {
   savedViews: () => req<Record<string, string[]>>("/me/views"),
   saveViews: (views: Record<string, string[]>) =>
     req<Record<string, string[]>>("/me/views", { method: "PUT", body: JSON.stringify(views) }),
+
+  // ----- gamification (issue #137) ----------------------------------------
+  meStats: () => req<MeStats>("/me/stats"),
+  meStreak: () => req<MeStreak>("/me/streak"),
+  meHistory: (days: number) => req<MeHistoryDay[]>(`/me/history?days=${days}`),
+  meBadges: () => req<MeBadges>("/me/badges"),
+  meActivity: (params: { kind?: string; since?: string; until?: string; limit?: number } = {}) => {
+    const qs = new URLSearchParams();
+    if (params.kind) qs.set("kind", params.kind);
+    if (params.since) qs.set("since", params.since);
+    if (params.until) qs.set("until", params.until);
+    if (params.limit != null) qs.set("limit", String(params.limit));
+    const tail = qs.toString();
+    return req<MeActivityEvent[]>(`/me/activity${tail ? "?" + tail : ""}`);
+  },
+  setMyTz: (tz: string) =>
+    req<{ status: string; tz: string }>("/me/tz", {
+      method: "PATCH",
+      body: JSON.stringify({ tz }),
+    }),
 };
+
+// ----- gamification response shapes (issue #137) --------------------------
+
+export interface MeStats {
+  as_of: string;
+  tz: string;
+  tasks_closed: { today: number; week: number; month: number; lifetime: number };
+  notes_touched: { week: number; month: number };
+  current_streak_days: number;
+  longest_streak_days: number;
+  rest_tokens_remaining: number;
+  on_time_eta_rate_30d: number | null;
+  on_time_sample_30d: number;
+  favorite_project_30d: string | null;
+  by_kind: Record<string, number>;
+}
+
+export interface MeStreak {
+  current_streak_days: number;
+  longest_streak_days: number;
+  rest_tokens_remaining: number;
+  as_of: string;
+}
+
+export interface MeHistoryDay {
+  date: string;
+  closes: number;
+  edits: number;
+}
+
+export interface EarnedBadge {
+  key: string;
+  title: string;
+  description: string;
+  awarded_at: string;
+}
+
+export interface LockedBadge {
+  key: string;
+  title: string;
+  description: string;
+  progress: number | null;
+}
+
+export interface MeBadges {
+  earned: EarnedBadge[];
+  locked: LockedBadge[];
+  hidden_locked_count: number;
+  total_count: number;
+}
+
+export interface MeActivityEvent {
+  id: number;
+  kind: string;
+  ref: string | null;
+  ts: string;
+  meta: Record<string, unknown>;
+}

--- a/VegaNotes/frontend/src/components/Me/ActivityList.tsx
+++ b/VegaNotes/frontend/src/components/Me/ActivityList.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api, type MeActivityEvent } from "../../api/client";
+
+const KIND_OPTIONS = [
+  "",
+  "task.created",
+  "task.closed",
+  "task.status",
+  "note.created",
+  "note.edited",
+] as const;
+
+function fmtTs(iso: string): string {
+  // Show local-readable date+time. The server emits ISO with no zone for
+  // naive UTC; we display whatever the browser parses.
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return iso;
+    return d.toLocaleString(undefined, {
+      month: "short", day: "numeric", hour: "2-digit", minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function ActivityList() {
+  const [kind, setKind] = useState<string>("");
+  const [limit, setLimit] = useState<number>(50);
+  const { data, isLoading, error } = useQuery<MeActivityEvent[]>({
+    queryKey: ["me", "activity", kind, limit],
+    queryFn: () => api.meActivity({ kind: kind || undefined, limit }),
+    staleTime: 15_000,
+  });
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h2 className="text-sm font-medium text-slate-700">Recent activity</h2>
+        <div className="flex items-center gap-2 text-xs">
+          <label className="text-slate-600">
+            kind{" "}
+            <select
+              className="border border-slate-300 rounded px-1 py-0.5"
+              value={kind}
+              onChange={(e) => setKind(e.target.value)}
+            >
+              {KIND_OPTIONS.map((k) => (
+                <option key={k} value={k}>{k || "all"}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-slate-600">
+            show{" "}
+            <select
+              className="border border-slate-300 rounded px-1 py-0.5"
+              value={limit}
+              onChange={(e) => setLimit(Number(e.target.value))}
+            >
+              {[25, 50, 100, 200].map((n) => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+      {isLoading && <div className="text-sm text-slate-500">Loading…</div>}
+      {error && <div className="text-sm text-rose-700">Failed to load activity.</div>}
+      {data && data.length === 0 && <p className="text-sm text-slate-500">No events.</p>}
+      {data && data.length > 0 && (
+        <div className="rounded border border-slate-200 bg-white overflow-hidden">
+          <table className="w-full text-xs">
+            <thead className="bg-slate-50 text-slate-600">
+              <tr>
+                <th className="text-left px-2 py-1.5">when</th>
+                <th className="text-left px-2 py-1.5">kind</th>
+                <th className="text-left px-2 py-1.5">ref</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((ev) => (
+                <tr key={ev.id} className="border-t border-slate-100">
+                  <td className="px-2 py-1 text-slate-600 whitespace-nowrap">{fmtTs(ev.ts)}</td>
+                  <td className="px-2 py-1 font-mono text-slate-800">{ev.kind}</td>
+                  <td className="px-2 py-1 font-mono text-slate-500">{ev.ref ?? ""}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/VegaNotes/frontend/src/components/Me/BadgeGrid.tsx
+++ b/VegaNotes/frontend/src/components/Me/BadgeGrid.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api, type MeBadges } from "../../api/client";
+
+function fmtDate(iso: string): string {
+  // Trim to YYYY-MM-DD; full timestamp clutters the tile.
+  return iso.slice(0, 10);
+}
+
+export function BadgeGrid() {
+  const [showLocked, setShowLocked] = useState(true);
+  const { data, isLoading, error } = useQuery<MeBadges>({
+    queryKey: ["me", "badges"],
+    queryFn: () => api.meBadges(),
+    staleTime: 30_000,
+  });
+  if (isLoading) return <div className="rounded border border-slate-200 p-4 text-slate-500">Loading badges…</div>;
+  if (error) return <div className="rounded border border-rose-200 p-4 text-rose-700">Failed to load badges.</div>;
+  if (!data) return null;
+
+  const earnedCount = data.earned.length;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h2 className="text-sm font-medium text-slate-700">
+          Badges{" "}
+          <span className="text-xs text-slate-500 font-normal">
+            {earnedCount} / {data.total_count} earned
+          </span>
+        </h2>
+        <label className="text-xs text-slate-600 inline-flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={showLocked}
+            onChange={(e) => setShowLocked(e.target.checked)}
+          />
+          show locked
+        </label>
+      </div>
+
+      {earnedCount === 0 && data.locked.length === 0 && data.hidden_locked_count === 0 && (
+        <p className="text-sm text-slate-500">No badges available yet.</p>
+      )}
+
+      {earnedCount > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+          {data.earned.map((b) => (
+            <div
+              key={b.key}
+              className="rounded border border-amber-300 bg-amber-50 p-3"
+              title={b.description}
+            >
+              <div className="text-sm font-semibold text-amber-900">🏆 {b.title}</div>
+              <div className="text-xs text-amber-800/80 mt-0.5 line-clamp-2">{b.description}</div>
+              <div className="text-[10px] text-amber-700 mt-1">earned {fmtDate(b.awarded_at)}</div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showLocked && data.locked.length > 0 && (
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-2">
+          {data.locked.map((b) => (
+            <div
+              key={b.key}
+              className="rounded border border-slate-200 bg-slate-50 p-3 opacity-80"
+              title={b.description}
+            >
+              <div className="text-sm font-semibold text-slate-600">🔒 {b.title}</div>
+              <div className="text-xs text-slate-500 mt-0.5 line-clamp-2">{b.description}</div>
+              {b.progress != null && (
+                <div className="mt-1.5">
+                  <div className="h-1.5 bg-slate-200 rounded overflow-hidden">
+                    <div
+                      className="h-full bg-sky-400"
+                      style={{ width: `${Math.round(Math.max(0, Math.min(1, b.progress)) * 100)}%` }}
+                    />
+                  </div>
+                  <div className="text-[10px] text-slate-500 mt-0.5">
+                    {Math.round(Math.max(0, Math.min(1, b.progress)) * 100)}%
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {data.hidden_locked_count > 0 && (
+        <p className="text-xs text-slate-500">
+          + {data.hidden_locked_count} hidden badge{data.hidden_locked_count === 1 ? "" : "s"} to discover
+        </p>
+      )}
+    </section>
+  );
+}

--- a/VegaNotes/frontend/src/components/Me/HistorySpark.tsx
+++ b/VegaNotes/frontend/src/components/Me/HistorySpark.tsx
@@ -1,0 +1,111 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api, type MeHistoryDay } from "../../api/client";
+
+const RANGES = [7, 30, 90] as const;
+type Range = typeof RANGES[number];
+
+export function HistorySpark() {
+  const [days, setDays] = useState<Range>(30);
+  const { data, isLoading, error } = useQuery<MeHistoryDay[]>({
+    queryKey: ["me", "history", days],
+    queryFn: () => api.meHistory(days),
+    staleTime: 30_000,
+  });
+
+  const max = useMemo(() => {
+    if (!data || data.length === 0) return 1;
+    return Math.max(1, ...data.map((d) => Math.max(d.closes, d.edits)));
+  }, [data]);
+
+  if (isLoading) return <div className="rounded border border-slate-200 p-4 text-slate-500">Loading history…</div>;
+  if (error) return <div className="rounded border border-rose-200 p-4 text-rose-700">Failed to load history.</div>;
+  if (!data) return null;
+
+  const W = Math.max(1, data.length);
+  const H = 60;
+  const COL = 8; // px per day
+  const totalW = W * COL;
+
+  const sumCloses = data.reduce((a, d) => a + d.closes, 0);
+  const sumEdits = data.reduce((a, d) => a + d.edits, 0);
+
+  return (
+    <section className="space-y-2">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h2 className="text-sm font-medium text-slate-700">
+          History{" "}
+          <span className="text-xs text-slate-500 font-normal">
+            {sumCloses} close{sumCloses === 1 ? "" : "s"} · {sumEdits} note edit{sumEdits === 1 ? "" : "s"}
+          </span>
+        </h2>
+        <div className="inline-flex rounded border border-slate-300 overflow-hidden text-xs">
+          {RANGES.map((r) => (
+            <button
+              key={r}
+              type="button"
+              onClick={() => setDays(r)}
+              className={`px-2 py-1 ${
+                r === days ? "bg-sky-100 text-sky-900" : "bg-white text-slate-600 hover:bg-slate-50"
+              }`}
+            >
+              {r}d
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {data.length === 0 ? (
+        <p className="text-sm text-slate-500">No activity in this window.</p>
+      ) : (
+        <div className="rounded border border-slate-200 bg-white p-3 overflow-x-auto">
+          <svg width={totalW} height={H + 18} role="img" aria-label="closes and edits per day">
+            {data.map((d, i) => {
+              const x = i * COL;
+              const closesH = (d.closes / max) * H;
+              const editsH = (d.edits / max) * H;
+              const barW = COL - 2;
+              return (
+                <g key={d.date}>
+                  <title>{`${d.date}: ${d.closes} closed, ${d.edits} edited`}</title>
+                  <rect
+                    x={x}
+                    y={H - editsH}
+                    width={barW / 2}
+                    height={editsH}
+                    fill="#bae6fd"
+                  />
+                  <rect
+                    x={x + barW / 2}
+                    y={H - closesH}
+                    width={barW / 2}
+                    height={closesH}
+                    fill="#0369a1"
+                  />
+                </g>
+              );
+            })}
+            {data.length > 0 && (
+              <>
+                <text x={0} y={H + 12} fontSize="9" fill="#64748b">{data[0].date}</text>
+                <text
+                  x={totalW}
+                  y={H + 12}
+                  fontSize="9"
+                  fill="#64748b"
+                  textAnchor="end"
+                >
+                  {data[data.length - 1].date}
+                </text>
+              </>
+            )}
+          </svg>
+          <div className="text-[10px] text-slate-500 flex gap-3 mt-1">
+            <span><span className="inline-block w-2 h-2 align-middle bg-[#0369a1] mr-1" />closes</span>
+            <span><span className="inline-block w-2 h-2 align-middle bg-[#bae6fd] mr-1" />edits</span>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/VegaNotes/frontend/src/components/Me/MeView.tsx
+++ b/VegaNotes/frontend/src/components/Me/MeView.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { isGamifyEnabled, setGamifyEnabled, subscribeGamify } from "../../lib/gamify";
+import { StatsCard } from "./StatsCard";
+import { StreakCard } from "./StreakCard";
+import { BadgeGrid } from "./BadgeGrid";
+import { HistorySpark } from "./HistorySpark";
+import { ActivityList } from "./ActivityList";
+import { TZSettings } from "./TZSettings";
+
+export function MeView() {
+  const [enabled, setEnabled] = useState<boolean>(() => isGamifyEnabled());
+
+  useEffect(() => subscribeGamify(setEnabled), []);
+
+  return (
+    <div className="p-4 space-y-4 max-w-5xl">
+      <div className="flex items-baseline justify-between flex-wrap gap-2">
+        <h1 className="text-xl font-semibold">Me</h1>
+        <label className="text-xs text-slate-600 inline-flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setGamifyEnabled(e.target.checked)}
+          />
+          show gamification
+          <span className="text-slate-400">(client-side only — server keeps recording)</span>
+        </label>
+      </div>
+
+      {/* TZ is intentionally always visible — it's a general preference,
+          not gamification surfacing (mirrors CLI's `vn me tz` exemption). */}
+      <TZSettings />
+
+      {!enabled ? (
+        <div className="rounded border border-slate-200 bg-slate-50 p-6 text-sm text-slate-600">
+          Gamification is hidden. Re-enable it with the toggle above to see
+          your stats, streak, badges, history and activity. The server is
+          still recording events, so flipping it back on restores your full
+          history.
+        </div>
+      ) : (
+        <>
+          <StatsCard />
+          <StreakCard />
+          <BadgeGrid />
+          <HistorySpark />
+          <ActivityList />
+        </>
+      )}
+    </div>
+  );
+}

--- a/VegaNotes/frontend/src/components/Me/StatsCard.tsx
+++ b/VegaNotes/frontend/src/components/Me/StatsCard.tsx
@@ -1,0 +1,65 @@
+import { useQuery } from "@tanstack/react-query";
+import { api, type MeStats } from "../../api/client";
+
+function pct(n: number | null): string {
+  if (n == null) return "—";
+  return `${Math.round(n * 100)}%`;
+}
+
+function Stat({ label, value, hint }: { label: string; value: string | number; hint?: string }) {
+  return (
+    <div className="rounded border border-slate-200 bg-white px-3 py-2">
+      <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
+      <div className="text-2xl font-semibold text-slate-800 leading-tight">{value}</div>
+      {hint && <div className="text-xs text-slate-500 mt-0.5">{hint}</div>}
+    </div>
+  );
+}
+
+export function StatsCard() {
+  const { data, isLoading, error } = useQuery<MeStats>({
+    queryKey: ["me", "stats"],
+    queryFn: () => api.meStats(),
+    staleTime: 30_000,
+  });
+  if (isLoading) return <div className="rounded border border-slate-200 p-4 text-slate-500">Loading stats…</div>;
+  if (error) return <div className="rounded border border-rose-200 p-4 text-rose-700">Failed to load stats.</div>;
+  if (!data) return null;
+
+  const closes = data.tasks_closed;
+  const notes = data.notes_touched;
+  const onTimeHint = data.on_time_sample_30d
+    ? `${data.on_time_sample_30d} sample${data.on_time_sample_30d === 1 ? "" : "s"} (30d)`
+    : "no ETA hits in last 30d";
+  const byKindEntries = Object.entries(data.by_kind).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-baseline justify-between">
+        <h2 className="text-sm font-medium text-slate-700">Stats</h2>
+        <span className="text-xs text-slate-500">as of {data.as_of} · {data.tz}</span>
+      </div>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        <Stat label="Closed today" value={closes.today} />
+        <Stat label="Closed 7d" value={closes.week} />
+        <Stat label="Closed 30d" value={closes.month} />
+        <Stat label="Closed lifetime" value={closes.lifetime} />
+        <Stat label="Notes touched 7d" value={notes.week} />
+        <Stat label="Notes touched 30d" value={notes.month} />
+        <Stat label="On-time ETA (30d)" value={pct(data.on_time_eta_rate_30d)} hint={onTimeHint} />
+        <Stat label="Favorite project (30d)" value={data.favorite_project_30d ?? "—"} />
+      </div>
+      {byKindEntries.length > 0 && (
+        <div className="text-xs text-slate-600">
+          <span className="text-slate-500">By kind:</span>{" "}
+          {byKindEntries.map(([k, n], i) => (
+            <span key={k}>
+              {i > 0 && <span className="text-slate-300"> · </span>}
+              <span className="font-medium">{k}</span> {n}
+            </span>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/VegaNotes/frontend/src/components/Me/StreakCard.tsx
+++ b/VegaNotes/frontend/src/components/Me/StreakCard.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+import { api, type MeStreak } from "../../api/client";
+
+export function StreakCard() {
+  const { data, isLoading, error } = useQuery<MeStreak>({
+    queryKey: ["me", "streak"],
+    queryFn: () => api.meStreak(),
+    staleTime: 30_000,
+  });
+  if (isLoading) return <div className="rounded border border-slate-200 p-4 text-slate-500">Loading streak…</div>;
+  if (error) return <div className="rounded border border-rose-200 p-4 text-rose-700">Failed to load streak.</div>;
+  if (!data) return null;
+
+  return (
+    <section className="rounded border border-slate-200 bg-white p-4 flex items-center gap-6 flex-wrap">
+      <div>
+        <div className="text-xs uppercase tracking-wide text-slate-500">Current streak</div>
+        <div className="text-3xl font-semibold text-sky-700">
+          {data.current_streak_days}
+          <span className="text-base font-normal text-slate-500"> day{data.current_streak_days === 1 ? "" : "s"}</span>
+        </div>
+      </div>
+      <div>
+        <div className="text-xs uppercase tracking-wide text-slate-500">Longest</div>
+        <div className="text-2xl font-semibold text-slate-800">
+          {data.longest_streak_days}
+          <span className="text-base font-normal text-slate-500"> d</span>
+        </div>
+      </div>
+      <div>
+        <div className="text-xs uppercase tracking-wide text-slate-500">Rest tokens</div>
+        <div className="text-2xl font-semibold text-slate-800">{data.rest_tokens_remaining}<span className="text-base font-normal text-slate-500"> /14d</span></div>
+      </div>
+      <div className="ml-auto text-xs text-slate-400">as of {data.as_of}</div>
+    </section>
+  );
+}

--- a/VegaNotes/frontend/src/components/Me/TZSettings.tsx
+++ b/VegaNotes/frontend/src/components/Me/TZSettings.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../../api/client";
+
+/** Read+write the caller's IANA timezone via /api/me. Free-text; the
+ * server validates against the IANA database and rejects unknown zones. */
+export function TZSettings() {
+  const qc = useQueryClient();
+  const { data: me } = useQuery({ queryKey: ["me"], queryFn: () => api.me() });
+  const [draft, setDraft] = useState<string>("");
+  const [editing, setEditing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const mut = useMutation({
+    mutationFn: (tz: string) => api.setMyTz(tz),
+    onSuccess: () => {
+      setEditing(false);
+      setError(null);
+      qc.invalidateQueries({ queryKey: ["me"] });
+      qc.invalidateQueries({ queryKey: ["me", "stats"] });
+      qc.invalidateQueries({ queryKey: ["me", "streak"] });
+      qc.invalidateQueries({ queryKey: ["me", "history"] });
+    },
+    onError: (e: unknown) => {
+      setError(e instanceof Error ? e.message : "Failed to save timezone");
+    },
+  });
+
+  const current = me?.tz ?? "UTC";
+
+  return (
+    <section className="rounded border border-slate-200 bg-white p-3 flex items-center gap-3 text-sm flex-wrap">
+      <span className="text-slate-600">Timezone:</span>
+      {!editing ? (
+        <>
+          <code className="text-slate-800">{current}</code>
+          <button
+            type="button"
+            className="text-xs text-sky-700 hover:underline"
+            onClick={() => { setDraft(current === "UTC" ? "" : current); setEditing(true); }}
+          >
+            change
+          </button>
+        </>
+      ) : (
+        <>
+          <input
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="e.g. America/Los_Angeles (empty = UTC)"
+            className="border border-slate-300 rounded px-2 py-1 text-xs w-72"
+            autoFocus
+          />
+          <button
+            type="button"
+            className="text-xs rounded border border-sky-400 bg-sky-50 text-sky-800 px-2 py-1"
+            onClick={() => mut.mutate(draft.trim())}
+            disabled={mut.isPending}
+          >
+            {mut.isPending ? "saving…" : "save"}
+          </button>
+          <button
+            type="button"
+            className="text-xs text-slate-600 hover:underline"
+            onClick={() => { setEditing(false); setError(null); }}
+          >
+            cancel
+          </button>
+        </>
+      )}
+      <span className="text-xs text-slate-500 ml-auto">
+        Streaks roll over at local midnight in your timezone.
+      </span>
+      {error && <div className="basis-full text-xs text-rose-700">{error}</div>}
+    </section>
+  );
+}

--- a/VegaNotes/frontend/src/components/Me/UnlockToast.tsx
+++ b/VegaNotes/frontend/src/components/Me/UnlockToast.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { onAwardedBadges, type MeBadges } from "../../api/client";
+import { useUI } from "../../store/ui";
+import { isGamifyEnabled, subscribeGamify } from "../../lib/gamify";
+import { lookupBadge } from "./badgeBlurbs";
+
+interface Toast {
+  id: number;
+  key: string;
+  title: string;
+  blurb: string;
+}
+
+let _seq = 0;
+
+/**
+ * Listens for `awarded_badges` arrays surfaced by any write request via
+ * the global `onAwardedBadges` hook. Renders one stacked toast per
+ * unlocked key. Click-through routes the user to the Me view and the
+ * BadgeGrid query refetches so the new badge shows as earned.
+ *
+ * Suppressed entirely when the user has flipped gamification OFF
+ * (mirrors CLI `gamify=off` behaviour).
+ */
+export function UnlockToast() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const [enabled, setEnabled] = useState<boolean>(() => isGamifyEnabled());
+  const qc = useQueryClient();
+  const setView = useUI((s) => s.set);
+
+  useEffect(() => subscribeGamify(setEnabled), []);
+
+  useEffect(() => {
+    return onAwardedBadges((keys) => {
+      if (!isGamifyEnabled()) return;
+      // Pull whatever the cache knows about this user's badges so we can
+      // render the live title; fall back to the static blurb table.
+      const cached = qc.getQueryData<MeBadges>(["me", "badges"]);
+      const known = new Map<string, { title: string; description: string }>();
+      cached?.earned.forEach((b) => known.set(b.key, b));
+      cached?.locked.forEach((b) => known.set(b.key, b));
+      const fresh: Toast[] = keys.map((k) => {
+        const live = known.get(k);
+        const fb = lookupBadge(k);
+        return {
+          id: ++_seq,
+          key: k,
+          title: live?.title ?? fb.title,
+          blurb: live?.description ?? fb.blurb,
+        };
+      });
+      setToasts((prev) => [...prev, ...fresh]);
+      // Refetch badges so the grid reflects the unlock immediately.
+      qc.invalidateQueries({ queryKey: ["me", "badges"] });
+      qc.invalidateQueries({ queryKey: ["me", "stats"] });
+      qc.invalidateQueries({ queryKey: ["me", "streak"] });
+      // Auto-dismiss each toast after 6 seconds.
+      const ids = fresh.map((t) => t.id);
+      window.setTimeout(() => {
+        setToasts((prev) => prev.filter((t) => !ids.includes(t.id)));
+      }, 6000);
+    });
+  }, [qc]);
+
+  if (!enabled || toasts.length === 0) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 max-w-sm">
+      {toasts.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          className="text-left rounded-lg border border-amber-300 bg-amber-50 shadow-lg px-4 py-3 hover:bg-amber-100 cursor-pointer"
+          onClick={() => {
+            setView({ view: "me" });
+            setToasts((prev) => prev.filter((x) => x.id !== t.id));
+          }}
+          title="View badges"
+        >
+          <div className="text-sm font-semibold text-amber-900">🏆 Unlocked: {t.title}</div>
+          {t.blurb && <div className="text-xs text-amber-800/80 mt-0.5">{t.blurb}</div>}
+          <div className="text-[10px] text-amber-700 mt-1">click to view</div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/VegaNotes/frontend/src/components/Me/badgeBlurbs.ts
+++ b/VegaNotes/frontend/src/components/Me/badgeBlurbs.ts
@@ -1,0 +1,25 @@
+/** Static catalog of badge titles + flavor text, mirroring the CLI's
+ * `_BADGE_BLURBS` table and the backend `app/badges.py` CATALOG.
+ *
+ * The toast prefers the live server payload from `/api/me/badges` (so
+ * titles can drift server-side without a frontend ship) and falls back
+ * here when the badge isn't yet present in the user's response — e.g.
+ * the very first time a key is awarded, before badges has been refetched.
+ */
+export const BADGE_BLURBS: Record<string, { title: string; blurb: string }> = {
+  first_light:   { title: "First Light",   blurb: "close your first task" },
+  hat_trick:     { title: "Hat Trick",     blurb: "close 3 tasks in one day" },
+  big_day:       { title: "Big Day",       blurb: "close 5 tasks in one day" },
+  marathoner:    { title: "Marathoner",    blurb: "maintain a 10-day streak" },
+  centurion:     { title: "Centurion",     blurb: "close 100 tasks lifetime" },
+  on_time:       { title: "On Time",       blurb: "close 10 tasks on or before their ETA" },
+  ar_wrangler:   { title: "AR Wrangler",   blurb: "close 25 action requests" },
+  notebook:      { title: "Notebook",      blurb: "edit notes 50 times" },
+  early_bird:    { title: "Early Bird",    blurb: "close a task before 9am local" },
+  night_owl:     { title: "Night Owl",     blurb: "close a task after 10pm local" },
+  weekend_hero:  { title: "Weekend Hero",  blurb: "close a task on a weekend" },
+};
+
+export function lookupBadge(key: string): { title: string; blurb: string } {
+  return BADGE_BLURBS[key] ?? { title: key, blurb: "" };
+}

--- a/VegaNotes/frontend/src/lib/gamify.ts
+++ b/VegaNotes/frontend/src/lib/gamify.ts
@@ -1,0 +1,47 @@
+/**
+ * Client-side gamification opt-out, mirroring the CLI's `vn config gamify=on/off`.
+ *
+ * Stored in `localStorage` under `veganotes.gamify` ("on" | "off"); defaults
+ * to ON when unset. Server keeps recording either way, so flipping back on
+ * later restores the user's full history (consistent with Phase 4 design).
+ *
+ * Subscribers are notified synchronously when the value flips so the
+ * `<UnlockToast>` and `<MeView>` can react without a route change.
+ */
+
+const KEY = "veganotes.gamify";
+
+type Listener = (enabled: boolean) => void;
+const _listeners = new Set<Listener>();
+
+function _readRaw(): string | null {
+  try {
+    return typeof window !== "undefined" ? window.localStorage.getItem(KEY) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isGamifyEnabled(): boolean {
+  const raw = _readRaw();
+  // Default ON: only an explicit "off" disables it.
+  return raw !== "off";
+}
+
+export function setGamifyEnabled(enabled: boolean): void {
+  try {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(KEY, enabled ? "on" : "off");
+    }
+  } catch {
+    /* private mode / quota — ignore */
+  }
+  for (const fn of _listeners) {
+    try { fn(enabled); } catch { /* listener errors must not propagate */ }
+  }
+}
+
+export function subscribeGamify(fn: Listener): () => void {
+  _listeners.add(fn);
+  return () => _listeners.delete(fn);
+}

--- a/VegaNotes/frontend/src/store/ui.ts
+++ b/VegaNotes/frontend/src/store/ui.ts
@@ -15,7 +15,7 @@ export interface FilterState {
 
 interface UIState {
   filters: FilterState;
-  view: "editor" | "kanban" | "agenda" | "timeline" | "calendar" | "graph" | "admin" | "my-tasks";
+  view: "editor" | "kanban" | "agenda" | "timeline" | "calendar" | "graph" | "admin" | "my-tasks" | "me";
   set: (patch: Partial<UIState>) => void;
   patchFilters: (patch: Partial<FilterState>) => void;
   clearFilters: () => void;

--- a/VegaNotes/frontend/tests/awardedBadges.test.ts
+++ b/VegaNotes/frontend/tests/awardedBadges.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { onAwardedBadges } from "../src/api/client";
+
+// Re-import the module under test by spying on global fetch.
+const realFetch = globalThis.fetch;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  // Each test installs its own fetch stub.
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+describe("onAwardedBadges interceptor", () => {
+  it("fires once per write response that carries awarded_badges", async () => {
+    const seen: string[][] = [];
+    const unsub = onAwardedBadges((keys) => seen.push(keys));
+
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(200, { id: 1, awarded_badges: ["first_light", "hat_trick"] }),
+    ) as unknown as typeof fetch;
+
+    const { api } = await import("../src/api/client");
+    await api.updateTask(1, { status: "done" });
+    unsub();
+
+    expect(seen).toEqual([["first_light", "hat_trick"]]);
+  });
+
+  it("does NOT fire for GET responses even if they happen to include the key", async () => {
+    const seen: string[][] = [];
+    const unsub = onAwardedBadges((keys) => seen.push(keys));
+
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(200, [{ id: 1, awarded_badges: ["first_light"] }]),
+    ) as unknown as typeof fetch;
+
+    const { api } = await import("../src/api/client");
+    await api.meActivity({ limit: 5 });
+    unsub();
+
+    expect(seen).toEqual([]);
+  });
+
+  it("ignores write responses with no awarded_badges or empty array", async () => {
+    const seen: string[][] = [];
+    const unsub = onAwardedBadges((keys) => seen.push(keys));
+
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(200, { id: 1, awarded_badges: [] }),
+    ) as unknown as typeof fetch;
+
+    const { api } = await import("../src/api/client");
+    await api.updateTask(1, { status: "done" });
+    unsub();
+
+    expect(seen).toEqual([]);
+  });
+
+  it("does not propagate listener exceptions to the request caller", async () => {
+    const unsub = onAwardedBadges(() => {
+      throw new Error("boom");
+    });
+
+    globalThis.fetch = vi.fn(async () =>
+      jsonResponse(200, { id: 1, awarded_badges: ["first_light"] }),
+    ) as unknown as typeof fetch;
+
+    const { api } = await import("../src/api/client");
+    await expect(api.updateTask(1, { status: "done" })).resolves.toBeTruthy();
+    unsub();
+  });
+});

--- a/VegaNotes/frontend/tests/gamify.test.ts
+++ b/VegaNotes/frontend/tests/gamify.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { isGamifyEnabled, setGamifyEnabled, subscribeGamify } from "../src/lib/gamify";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("gamify opt-out", () => {
+  it("defaults to enabled when nothing is stored", () => {
+    expect(isGamifyEnabled()).toBe(true);
+  });
+
+  it("respects an explicit 'off'", () => {
+    setGamifyEnabled(false);
+    expect(window.localStorage.getItem("veganotes.gamify")).toBe("off");
+    expect(isGamifyEnabled()).toBe(false);
+  });
+
+  it("toggles back on", () => {
+    setGamifyEnabled(false);
+    setGamifyEnabled(true);
+    expect(isGamifyEnabled()).toBe(true);
+    expect(window.localStorage.getItem("veganotes.gamify")).toBe("on");
+  });
+
+  it("notifies subscribers on change", () => {
+    const seen: boolean[] = [];
+    const unsub = subscribeGamify((v) => seen.push(v));
+    setGamifyEnabled(false);
+    setGamifyEnabled(true);
+    unsub();
+    setGamifyEnabled(false);
+    expect(seen).toEqual([false, true]);
+  });
+
+  it("treats unknown raw values as enabled (lenient default)", () => {
+    window.localStorage.setItem("veganotes.gamify", "garbage");
+    expect(isGamifyEnabled()).toBe(true);
+  });
+});

--- a/VegaNotes/package-lock.json
+++ b/VegaNotes/package-lock.json
@@ -41,6 +41,7 @@
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.2.1",
         "autoprefixer": "^10.4.19",
+        "jsdom": "^29.1.0",
         "postcss": "^8.4.38",
         "tailwindcss": "^3.4.3",
         "typescript": "^5.4.0",
@@ -60,6 +61,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -341,6 +393,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -785,6 +990,24 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fullcalendar/core": {
@@ -2908,6 +3131,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3146,6 +3379,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3271,6 +3518,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3288,6 +3549,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
@@ -3649,6 +3917,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -3721,6 +4002,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -3756,6 +4044,57 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3893,6 +4232,13 @@
       "bin": {
         "markdown-it": "bin/markdown-it.mjs"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -4119,6 +4465,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-key": {
@@ -4629,6 +5001,16 @@
         "prosemirror-transform": "^1.1.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -4843,6 +5225,16 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -4949,6 +5341,19 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5106,6 +5511,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -5251,6 +5663,26 @@
         "@popperjs/core": "^2.9.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5262,6 +5694,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -5313,6 +5771,16 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -5574,6 +6042,54 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5606,6 +6122,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",


### PR DESCRIPTION
Implements Phase 5 of the VegaNotes solo gamification plan: surface stats, streaks, badges, history and activity in the React frontend. Closes #137.

## What changed

**Routing + nav**
- New `view: "me"` in `src/store/ui.ts`.
- `ViewSwitcher` renders `<MeView />` for it; `NavBar` exposes a `me` tab.

**Components (`src/components/Me/`)**
- `MeView.tsx` — top-level page, opt-out toggle, layout.
- `StatsCard.tsx` — closes (today / 7d / 30d / lifetime), notes touched (7d / 30d), on-time-ETA rate (with sample size hint), favorite project, by-kind breakdown. Powered by `GET /api/me/stats`.
- `StreakCard.tsx` — current + longest streak + rest tokens. `GET /api/me/streak`.
- `BadgeGrid.tsx` — earned badges as filled amber tiles, locked tiles with progress bar, `+N hidden` footer for undiscovered, `show locked` checkbox.
- `HistorySpark.tsx` — inline SVG bar pair (closes vs. edits) per day with 7 / 30 / 90 day toggle, hover tooltip per bar, totals header.
- `ActivityList.tsx` — recent events with `kind` filter and `limit` selector.
- `TZSettings.tsx` — read/write the user's IANA TZ. Free-text input, server-side validated.
- `UnlockToast.tsx` — global toast that subscribes to `onAwardedBadges`, stacks one per key, click-through to MeView, auto-dismiss after 6s, refetches badges/stats/streak.
- `badgeBlurbs.ts` — static title/blurb fallback that mirrors the CLI table.

**API client (`src/api/client.ts`)**
- Adds `meStats`, `meStreak`, `meHistory`, `meBadges`, `meActivity`, `setMyTz` and matching response interfaces.
- One-time `onAwardedBadges(fn)` interceptor: every non-GET response that carries a non-empty `awarded_badges` array (Phase 4 backend already emits this) fires registered listeners. Listener exceptions are swallowed so a buggy subscriber can't break the request.
- `me()` now returns `tz?: string` to match the backend contract used by `TZSettings`.

**Opt-out (`src/lib/gamify.ts`)**
- Client-side toggle persisted in `localStorage.veganotes.gamify` (default ON; only `"off"` disables). Mirrors CLI `vn config gamify=on/off` semantics.
- `MeView` toggle flips it; `UnlockToast` suppresses itself when off.
- Server keeps recording either way, so flipping back on restores history.
- TZ widget is **exempt** from the opt-out because timezone is a general preference, not gamification surfacing (matches CLI's `vn me tz` exemption).

**Tests**
- `tests/gamify.test.ts` — opt-out default, persistence, subscriber notifications, lenient parse for unknown raw values (uses jsdom for `localStorage`).
- `tests/awardedBadges.test.ts` — interceptor fires only on non-GET responses, ignores empty arrays, swallows listener exceptions.
- Adds `jsdom` as a `devDependency` (the existing tests don't need a DOM, the new opt-out tests do; per-file `// @vitest-environment jsdom` directive keeps the default test environment unchanged).

**Docs**
- `VegaNotes/README.md` mentions the new `Me` view and the per-client opt-out toggle.

## Validation
- `npm run lint` (tsc --noEmit): clean.
- `npm run build`: clean.
- `npm test`: **48 passed** (43 existing + 5 opt-out + a fresh 4 for the interceptor).

## Deferred (per Phase 5 plan, not blocking)
- Server-side enforcement of the opt-out.
- Full IANA TZ picker (today's free-text input is server-validated; an autocomplete is a follow-up).
- Component tests with React Testing Library — vitest is wired but RTL is not in the dep tree; smoke e2e via Playwright is also a follow-up.
- `vn me reset` and a corresponding UI button.