### PR TITLE
feat(veganotes): two-axis etag (prose + tasks) — design 8d

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -27,6 +27,7 @@ from ..markdown_ops import (
     inject_missing_ids, replace_attr, replace_multi_attr, replace_notes,
     append_note, generate_task_id, existing_ids, delete_task_block,
     insert_ar_under_task,
+    merge_with_disk_tasks,
     remove_attr, roll_to_next_week, update_task_status,
     find_ref_row_lines, patch_ref_rows, insert_ar_ref_row_after,
 )
@@ -36,7 +37,8 @@ from ..models import (
 )
 from ..parser import parse
 from ..safe_io import (
-    StaleWriteError, _safe_write_unlocked, etag_for, etag_for_bytes, safe_write, with_file_lock,
+    StaleWriteError, _safe_write_unlocked, etag_components, etag_for,
+    etag_for_bytes, safe_write, with_file_lock,
 )
 from .. import gamify
 from ..phonebook import get_phonebook
@@ -439,6 +441,13 @@ class NoteIn(BaseModel):
     # etag to match exactly. Mismatch -> 409 with the current content + etag
     # so the client can reconcile. See issue #60.
     if_match: Optional[str] = None
+    # Design 8d: two-axis etag. When ``if_match_prose`` is provided the
+    # server only requires the *prose* component of the disk etag to
+    # match; popover-driven task-line drift on disk is reconciled via
+    # :func:`merge_with_disk_tasks` so the user's free-text edits land
+    # without colliding on every concurrent ``PATCH /tasks/...``. See
+    # checkpoint "Implementing two-axis etag design 8d".
+    if_match_prose: Optional[str] = None
 
 
 @router.get("/notes")
@@ -476,9 +485,12 @@ def note_etag(
     if not full.exists() or not full.is_file():
         raise HTTPException(404, "note not found")
     disk_md = full.read_text(encoding="utf-8")
+    components = etag_components(disk_md)
     return {
         "path": path,
         "etag": etag_for_bytes(disk_md.encode()),
+        "prose_etag": components["prose"],
+        "tasks_etag": components["tasks"],
         "mtime": full.stat().st_mtime,
     }
 
@@ -503,10 +515,13 @@ def get_note(
     else:
         disk_md = n.body_md  # fallback if file somehow missing
         disk_etag = etag_for(full)
+    components = etag_components(disk_md)
     return {
         "id": n.id, "path": n.path, "title": n.title,
         "body_md": disk_md, "updated_at": n.updated_at,
         "etag": disk_etag,
+        "prose_etag": components["prose"],
+        "tasks_etag": components["tasks"],
     }
 
 
@@ -531,14 +546,48 @@ def upsert_note(
     expected = body.if_match if body.if_match is not None else if_match
     pre_existing = full.exists()
     pre_body = full.read_text(encoding="utf-8") if pre_existing else ""
+
+    # Design 8d: prose-aware concurrency. If the client sent
+    # ``if_match_prose`` we ignore byte-level ``if_match`` and instead
+    # accept the write as long as the *prose* component of the on-disk
+    # file matches what the client started from. We then merge the
+    # client's prose with whatever task lines are currently on disk so
+    # popover ``PATCH /tasks/...`` writes that landed during the typing
+    # session are preserved. See checkpoint
+    # "Implementing two-axis etag design 8d".
+    write_md = body.body_md
+    if body.if_match_prose is not None and pre_existing:
+        with with_file_lock(full):
+            disk_now = full.read_text(encoding="utf-8")
+            disk_components = etag_components(disk_now)
+            if disk_components["prose"] != body.if_match_prose:
+                # Genuine prose-vs-prose conflict — surface to the user.
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "error": "stale_prose",
+                        "message": "the prose changed under you; reload before saving",
+                        "current_content": disk_now,
+                        "current_etag": etag_for_bytes(disk_now.encode()),
+                        "current_prose_etag": disk_components["prose"],
+                        "current_tasks_etag": disk_components["tasks"],
+                    },
+                )
+            # Prose matches — overlay disk's task lines onto the
+            # incoming prose buffer and rewrite. Bypass the byte-etag
+            # check below by clearing ``expected``: the prose-axis
+            # check we just performed is the authoritative gate.
+            write_md = merge_with_disk_tasks(body.body_md, disk_now)
+            expected = None
     try:
         new_etag = safe_write(
-            full, body.body_md,
+            full, write_md,
             notes_dir=settings.notes_dir, expected_etag=expected,
         )
     except StaleWriteError as e:
         # 409 Conflict — body carries current content + etag for the
         # client to surface a recovery / merge UI. See issue #60.
+        cur_components = etag_components(e.current_content or "")
         raise HTTPException(
             status_code=409,
             detail={
@@ -546,17 +595,27 @@ def upsert_note(
                 "message": "the file changed under you; reload before saving",
                 "current_content": e.current_content,
                 "current_etag": e.current_etag,
+                "current_prose_etag": cur_components["prose"],
+                "current_tasks_etag": cur_components["tasks"],
             },
         )
     note = reindex_file(full, s)
     awarded: list[str] = []
     if not pre_existing:
         awarded = gamify.record_event(s, user, gamify.NOTE_CREATED, ref=body.path)
-    elif pre_body.strip() != body.body_md.strip():
+    elif pre_body.strip() != write_md.strip():
         # Skip whitespace-only / no-op writes so streaks aren't gamed by
         # repeatedly saving an unchanged file.
         awarded = gamify.record_event(s, user, gamify.NOTE_EDITED, ref=body.path)
-    out: dict[str, Any] = {"id": note.id, "path": note.path, "etag": new_etag}
+    final_md = full.read_text(encoding="utf-8") if full.exists() else write_md
+    final_components = etag_components(final_md)
+    out: dict[str, Any] = {
+        "id": note.id,
+        "path": note.path,
+        "etag": new_etag,
+        "prose_etag": final_components["prose"],
+        "tasks_etag": final_components["tasks"],
+    }
     if awarded:
         out["awarded_badges"] = awarded
     return out

--- a/VegaNotes/backend/app/markdown_ops.py
+++ b/VegaNotes/backend/app/markdown_ops.py
@@ -1060,3 +1060,162 @@ def insert_ar_ref_row_after(
     new_line = new_line + nl
     new_lines = lines[: insert_after + 1] + [new_line] + lines[insert_after + 1 :]
     return "".join(new_lines), True
+
+
+# Match any of the canonical task-id token prefixes anywhere in a line:
+#   - a declaration carries `#id T-XXX`
+#   - a ref row leads with `#task T-XXX` or `#AR T-XXX`
+# All three resolve to the same uuid so the merge can identify "same task"
+# regardless of whether the line is the source-of-truth declaration or a
+# cross-file reference.
+_TASK_UUID_RE = re.compile(r"#(?:id|task|ar)\s+(T-[A-Za-z0-9]+)", re.IGNORECASE)
+
+
+def _task_uuid(line: str) -> Optional[str]:
+    m = _TASK_UUID_RE.search(line)
+    return m.group(1).upper() if m else None
+
+
+def _split_into_blocks(md: str) -> list[tuple[str, list[str], Optional[str]]]:
+    """Split ``md`` into ordered ``(kind, lines, uuid)`` blocks.
+
+    A block is one of:
+
+    - ``("prose", [line], None)`` — a single non-task line (free text,
+      heading, top-level ``@admin`` / ``#project`` context, blank line).
+      Each prose line is its own block so ordering relative to surrounding
+      task blocks survives the merge.
+
+    - ``("task", [decl_line, *continuations], uuid)`` — a contiguous run
+      starting with the first task-classified line that carries an
+      identifiable uuid (declaration **or** ref row), plus any following
+      task-classified continuation/ref lines that don't introduce a new
+      uuid. The block's ``uuid`` is the first uuid encountered. Lines
+      with no identifiable uuid produce an "anonymous" task block (uuid
+      is ``None``) which the merge keeps verbatim from the incoming side
+      because we have no way to align them to the disk version.
+
+    Used by :func:`merge_with_disk_tasks` to align incoming and disk task
+    blocks by uuid and emit a 3-way-style result without having to do a
+    real diff.
+    """
+    from .parser import classify_lines  # lazy: parser imports may cycle
+
+    lines = md.splitlines()
+    classes = classify_lines(md)
+    out: list[tuple[str, list[str], Optional[str]]] = []
+    cur: list[str] = []
+    cur_uuid: Optional[str] = None
+    cur_open = False
+
+    def flush() -> None:
+        nonlocal cur, cur_uuid, cur_open
+        if cur_open and cur:
+            out.append(("task", cur, cur_uuid))
+        cur = []
+        cur_uuid = None
+        cur_open = False
+
+    for line, cls in zip(lines, classes):
+        if cls != "task":
+            flush()
+            out.append(("prose", [line], None))
+            continue
+        u = _task_uuid(line)
+        if u is not None:
+            # New task block whenever a uuid-bearing line appears: start a
+            # fresh block keyed on this uuid. Continuations without their
+            # own uuid then attach to it below.
+            flush()
+            cur = [line]
+            cur_uuid = u
+            cur_open = True
+            continue
+        if cur_open:
+            cur.append(line)
+        else:
+            # Task-classified line with no uuid and no open block — keep it
+            # as an anonymous task block of one line. (Rare: malformed or
+            # mid-edit task line. The merge will keep it verbatim.)
+            out.append(("task", [line], None))
+    flush()
+    return out
+
+
+def merge_with_disk_tasks(incoming: str, disk: str) -> str:
+    """Merge a free-text-edited buffer with the live disk task overlay.
+
+    Design 8d ("two-axis etag") server-side merge: the editor sends an
+    ``incoming`` buffer that the user has been freely typing in. While
+    they were typing, popover ``PATCH /tasks/...`` operations may have
+    rewritten task lines on disk. The naive write would clobber those
+    popover edits.
+
+    This helper rebuilds the file by:
+
+    1. Walking ``incoming`` block-by-block (see :func:`_split_into_blocks`).
+       Every prose block is emitted **as-is** — these are the user's
+       free-text edits, the source of truth for the prose axis.
+    2. For each incoming task block with a uuid, look up the same uuid
+       in ``disk``. If found, emit ``disk``'s version of that block
+       instead — popover writes win on the task axis. If not found
+       (task was deleted via popover while the user was typing), drop
+       it from the output.
+    3. Anonymous task blocks (no uuid) and uuid-less continuations are
+       emitted from ``incoming``.
+    4. After the walk, append any disk-only task blocks (uuids the
+       popover added that the editor didn't have) at the end of the
+       file, separated by a single blank line.
+
+    Trailing newline is preserved if ``incoming`` had one. Whitespace
+    normalization is left to ``safe_io._normalize_for_disk`` which runs
+    after merge in the write path.
+
+    Note: this is **not** a general 3-way text merge. It assumes the
+    only structured edits to task lines come through the popover/PATCH
+    path. If a user typed inside a task line in the editor while a
+    popover ran for the same task, the popover wins (consistent with
+    the popover being the structured-write source of truth). The user's
+    in-buffer edit to that task line is discarded — the
+    "tasks_etag drifted" signal in ``current_state`` lets the frontend
+    show a non-blocking notification later if desired.
+    """
+    inc_blocks = _split_into_blocks(incoming)
+    disk_blocks = _split_into_blocks(disk)
+    disk_by_uuid: dict[str, list[str]] = {}
+    disk_order: list[str] = []
+    for kind, lines, uuid in disk_blocks:
+        if kind == "task" and uuid is not None:
+            disk_by_uuid[uuid] = lines
+            disk_order.append(uuid)
+
+    consumed: set[str] = set()
+    out_lines: list[str] = []
+    for kind, lines, uuid in inc_blocks:
+        if kind == "prose":
+            out_lines.extend(lines)
+            continue
+        if uuid is None:
+            out_lines.extend(lines)
+            continue
+        if uuid in disk_by_uuid:
+            out_lines.extend(disk_by_uuid[uuid])
+            consumed.add(uuid)
+        # else: popover-deleted, drop the block.
+
+    # Append disk-only task blocks (popover-added during edit) in disk order
+    # at the end, with a separating blank line for readability.
+    appended_any = False
+    for uuid in disk_order:
+        if uuid in consumed:
+            continue
+        if not appended_any:
+            if out_lines and out_lines[-1].strip():
+                out_lines.append("")
+            appended_any = True
+        out_lines.extend(disk_by_uuid[uuid])
+
+    merged = "\n".join(out_lines)
+    if incoming.endswith("\n") and not merged.endswith("\n"):
+        merged += "\n"
+    return merged

--- a/VegaNotes/backend/app/parser/__init__.py
+++ b/VegaNotes/backend/app/parser/__init__.py
@@ -1,9 +1,9 @@
-from .parser import parse, slugify
+from .parser import classify_lines, parse, slugify
 from .tokens import REGISTRY, TokenSpec, is_known
 from .time_parse import parse_eta, parse_duration, parse_priority_rank, PRIORITY_ORDER
 
 __all__ = [
-    "parse", "slugify",
+    "classify_lines", "parse", "slugify",
     "REGISTRY", "TokenSpec", "is_known",
     "parse_eta", "parse_duration", "parse_priority_rank", "PRIORITY_ORDER",
 ]

--- a/VegaNotes/backend/app/parser/parser.py
+++ b/VegaNotes/backend/app/parser/parser.py
@@ -354,6 +354,81 @@ def parse(md: str) -> Dict[str, Any]:
     }
 
 
+def classify_lines(md: str) -> List[str]:
+    """Return per-line classification ``'task' | 'prose' | 'blank'`` for ``md``.
+
+    Used by Design 8d (decoupled-write-paths) to split the file's address
+    space into two axes:
+
+    - ``'task'`` lines participate in a parsed task record. These are the
+      lines the popover / PATCH endpoints surgically rewrite. Specifically:
+
+        * ``!task`` / ``!AR`` declaration lines.
+        * Ref rows whose first non-bullet token is ``#task <id>`` or
+          ``#ar <id>`` (cross-file references the popover propagates into).
+        * Attribute-only continuation lines indented strictly deeper than
+          the most recent task declaration (e.g. ``#note ...``,
+          indented ``#status``, etc).
+
+    - ``'prose'`` lines are everything else the user freely edits in the
+      .md editor: free text, headings, top-level context lines (``@admin``,
+      ``#project gfc``), etc. Popover writes never touch these.
+
+    - ``'blank'`` lines reset both the parser's task/context stacks and
+      this classifier's "current task" anchor. Counted as prose for
+      etag-component purposes.
+
+    Mirrors the line-by-line dispatch in :func:`parse` so a line's
+    classification matches the parser's actual disposition. If the parser
+    semantics ever diverge between the two paths, write-time behaviour
+    will drift from save-time concurrency expectations — keep them in
+    lock-step.
+    """
+    out: List[str] = []
+    current_task_indent: Optional[int] = None
+    for raw_line in md.splitlines():
+        if not raw_line.strip():
+            out.append("blank")
+            current_task_indent = None
+            continue
+        line_indent = _indent_level(raw_line)
+        items = lex(raw_line)
+        decl = next(
+            (x for x in items if isinstance(x, Token) and x.kind == "task_decl"),
+            None,
+        )
+        attr_toks = [x for x in items if isinstance(x, Token) and x.kind == "attr"]
+        if decl is not None:
+            out.append("task")
+            current_task_indent = line_indent
+            continue
+        if attr_toks:
+            ref = _is_ref_row(items)
+            if ref is not None:
+                out.append("task")
+                continue
+            if _is_context_only_line(items):
+                # Continuation if indented strictly deeper than the most
+                # recent open task; otherwise a top-level context line
+                # (prose for etag-component purposes — popover writes
+                # don't touch these).
+                if current_task_indent is not None and line_indent > current_task_indent:
+                    out.append("task")
+                else:
+                    out.append("prose")
+                continue
+            # Mixed prose+attr line attached to current task — attrs flow
+            # into the task record so we treat it as task content.
+            if current_task_indent is not None and line_indent > current_task_indent:
+                out.append("task")
+            else:
+                out.append("prose")
+            continue
+        # Plain prose (no tokens at all).
+        out.append("prose")
+    return out
+
+
 def _rollup_to_parents(tasks: List[ParsedTask]) -> None:
     """Back-propagate child state to parents:
 

--- a/VegaNotes/backend/app/safe_io.py
+++ b/VegaNotes/backend/app/safe_io.py
@@ -29,7 +29,7 @@ import os
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Dict, List, Optional
 
 
 class StaleWriteError(Exception):
@@ -82,6 +82,46 @@ def etag_for(path: Path) -> str:
 
 def etag_for_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
+
+
+def etag_components(md_text: str) -> Dict[str, str]:
+    """Compute two-axis etags (Design 8d) over a markdown buffer.
+
+    Returns a dict ``{'prose': sha256_hex, 'tasks': sha256_hex}`` where
+    each component hashes only the lines of that classification (see
+    :func:`app.parser.classify_lines`). Used by the editor concurrency
+    protocol so that:
+
+    - A popover ``PATCH /tasks/...`` that rewrites only ``task`` lines
+      changes ``tasks`` etag but leaves ``prose`` etag stable. The
+      free-text editor's poll loop, keyed on ``prose`` etag, doesn't see
+      a conflict and the user keeps typing.
+    - A free-text edit that touches only prose lines changes ``prose``
+      etag. The popover side tolerates ``tasks`` drift implicitly because
+      its writes are uuid-keyed.
+    - A genuine prose-vs-prose race still raises ``409 stale_prose`` and
+      the existing conflict-resolution UI fires.
+
+    Lazy-imports ``classify_lines`` to avoid the parser <-> safe_io
+    circular at module load time. ``blank`` lines are folded into the
+    prose component (they belong to free-text whitespace; the popover
+    never inserts/removes blank lines).
+    """
+    from .parser import classify_lines  # local import to break cycle
+
+    lines = md_text.splitlines()
+    classes = classify_lines(md_text)
+    prose_buf: List[str] = []
+    task_buf: List[str] = []
+    for line, cls in zip(lines, classes):
+        if cls == "task":
+            task_buf.append(line)
+        else:
+            prose_buf.append(line)
+    return {
+        "prose": hashlib.sha256("\n".join(prose_buf).encode("utf-8")).hexdigest(),
+        "tasks": hashlib.sha256("\n".join(task_buf).encode("utf-8")).hexdigest(),
+    }
 
 
 def _backup_path(notes_dir: Path, target: Path) -> Path:

--- a/VegaNotes/backend/data/phonebook.json
+++ b/VegaNotes/backend/data/phonebook.json
@@ -1,45 +1,11 @@
 {
-  "nsaddaga": {
-    "idsid": "nsaddaga",
-    "display": "Prasad Addagarla",
-    "email": "prasad.addagarla@intel.com",
+  "abolisaw": {
+    "idsid": "abolisaw",
+    "display": "Aboli Sawant",
+    "email": "aboli.sawant@intel.com",
     "aliases": [
-      "prasad",
-      "addagarla",
-      "prasad addagarla",
-      "p addagarla",
-      "admin"
-    ],
-    "prefer_subtrees": [
-      "eyitav"
-    ]
-  },
-  "nchatla": {
-    "idsid": "nchatla",
-    "display": "Niharika Chatla",
-    "email": "niharika1.chatla@intel.com",
-    "aliases": [
-      "chatla",
-      "chatla niharika",
-      "chatla, niharika",
-      "chatla, niharika1",
-      "niharika",
-      "niharika chatla",
-      "niharika1",
-      "niharika1.chatla"
-    ]
-  },
-  "yongxili": {
-    "idsid": "yongxili",
-    "display": "Yongxi Li",
-    "email": "yongxi.li@intel.com",
-    "aliases": [
-      "li",
-      "li yongxi",
-      "li, yongxi",
-      "yongxi",
-      "yongxi li",
-      "yongxi.li"
+      "aboli",
+      "aboli.sawant"
     ]
   },
   "alonhers": {
@@ -55,30 +21,13 @@
       "hershkovitz, alon"
     ]
   },
-  "ehezi": {
-    "idsid": "ehezi",
-    "display": "Elad Hezi",
-    "email": "elad.hezi@intel.com",
+  "ashar10": {
+    "idsid": "ashar10",
+    "display": "Atul Sharma",
+    "email": "atul.z.sharma@intel.com",
     "aliases": [
-      "elad",
-      "elad hezi",
-      "elad.hezi",
-      "hezi",
-      "hezi elad",
-      "hezi, elad"
-    ]
-  },
-  "ylaizer": {
-    "idsid": "ylaizer",
-    "display": "Yakir Laizer",
-    "email": "yakir.laizer@intel.com",
-    "aliases": [
-      "laizer",
-      "laizer yakir",
-      "laizer, yakir",
-      "yakir",
-      "yakir laizer",
-      "yakir.laizer"
+      "atul",
+      "atul.z.sharma"
     ]
   },
   "ayastein": {
@@ -116,6 +65,19 @@
       "edwin.f.mendez.valverde"
     ]
   },
+  "ehezi": {
+    "idsid": "ehezi",
+    "display": "Elad Hezi",
+    "email": "elad.hezi@intel.com",
+    "aliases": [
+      "elad",
+      "elad hezi",
+      "elad.hezi",
+      "hezi",
+      "hezi elad",
+      "hezi, elad"
+    ]
+  },
   "gajith": {
     "idsid": "gajith",
     "display": "Gautham Ajith",
@@ -123,6 +85,18 @@
     "aliases": [
       "gautham",
       "gautham.ajith"
+    ]
+  },
+  "gbandana": {
+    "idsid": "gbandana",
+    "display": "Gnanamaria Kushwanth Bandanadham",
+    "email": "gnanamaria.kushwanth.bandanadham@intel.com",
+    "aliases": [
+      "kushwanth",
+      "gnanamaria",
+      "bandanadham",
+      "gnanamaria kushwanth bandanadham",
+      "gnanamaria.kushwanth.bandanadham"
     ]
   },
   "khbyers": {
@@ -143,6 +117,21 @@
       "muana.kasongo"
     ]
   },
+  "nchatla": {
+    "idsid": "nchatla",
+    "display": "Niharika Chatla",
+    "email": "niharika1.chatla@intel.com",
+    "aliases": [
+      "chatla",
+      "chatla niharika",
+      "chatla, niharika",
+      "chatla, niharika1",
+      "niharika",
+      "niharika chatla",
+      "niharika1",
+      "niharika1.chatla"
+    ]
+  },
   "njammala": {
     "idsid": "njammala",
     "display": "Namratha Jammalamadugu",
@@ -150,6 +139,21 @@
     "aliases": [
       "namratha",
       "namratha.jammalamadugu"
+    ]
+  },
+  "nsaddaga": {
+    "idsid": "nsaddaga",
+    "display": "Prasad Addagarla",
+    "email": "prasad.addagarla@intel.com",
+    "aliases": [
+      "prasad",
+      "addagarla",
+      "prasad addagarla",
+      "p addagarla",
+      "admin"
+    ],
+    "prefer_subtrees": [
+      "eyitav"
     ]
   },
   "rnagarat": {
@@ -170,22 +174,30 @@
       "sachin.bhattad"
     ]
   },
-  "abolisaw": {
-    "idsid": "abolisaw",
-    "display": "Aboli Sawant",
-    "email": "aboli.sawant@intel.com",
+  "ylaizer": {
+    "idsid": "ylaizer",
+    "display": "Yakir Laizer",
+    "email": "yakir.laizer@intel.com",
     "aliases": [
-      "aboli",
-      "aboli.sawant"
+      "laizer",
+      "laizer yakir",
+      "laizer, yakir",
+      "yakir",
+      "yakir laizer",
+      "yakir.laizer"
     ]
   },
-  "ashar10": {
-    "idsid": "ashar10",
-    "display": "Atul Sharma",
-    "email": "atul.z.sharma@intel.com",
+  "yongxili": {
+    "idsid": "yongxili",
+    "display": "Yongxi Li",
+    "email": "yongxi.li@intel.com",
     "aliases": [
-      "atul",
-      "atul.z.sharma"
+      "li",
+      "li yongxi",
+      "li, yongxi",
+      "yongxi",
+      "yongxi li",
+      "yongxi.li"
     ]
   }
 }

--- a/VegaNotes/backend/tests/api/test_api.py
+++ b/VegaNotes/backend/tests/api/test_api.py
@@ -2121,3 +2121,145 @@ def test_rollover_rejects_target_collision(client):
         headers={"Authorization": AUTH},
     )
     assert r.status_code == 409, r.text
+
+
+# ---------------------------------------------------------------------------
+# Design 8d: two-axis etag (prose + tasks)
+# ---------------------------------------------------------------------------
+
+def _put_8d(client, path: str, body_md: str, *, if_match: str | None = None,
+             if_match_prose: str | None = None) -> object:
+    payload = {"path": path, "body_md": body_md}
+    if if_match_prose is not None:
+        payload["if_match_prose"] = if_match_prose
+    headers = {"Authorization": AUTH}
+    if if_match is not None:
+        headers["If-Match"] = if_match
+    return client.put("/api/notes", json=payload, headers=headers)
+
+
+def test_8d_get_endpoints_return_split_etags(client):
+    """``GET /notes/etag`` and ``GET /notes/{id}`` both expose
+    ``prose_etag`` + ``tasks_etag`` alongside the legacy byte-level etag.
+
+    Without these axes the editor's 5 s freshness poll cannot tell
+    "popover patched a task line" apart from "someone else edited the
+    prose underneath you", and every popover write triggers a false
+    conflict banner.
+    """
+    body = (
+        "# 8d header\n\n"
+        "@admin\n\n"
+        "- !task Foo #id T-8DAA01 #owner @admin #status todo\n"
+        "- !task Bar #id T-8DAA02 #owner @admin #status todo\n\n"
+        "free prose tail\n"
+    )
+    r = _put_8d(client, "8d_split.md", body)
+    assert r.status_code == 200, r.text
+    note_id = r.json()["id"]
+    assert "prose_etag" in r.json() and "tasks_etag" in r.json()
+
+    r = client.get(f"/api/notes/{note_id}", headers={"Authorization": AUTH})
+    assert r.status_code == 200
+    assert "prose_etag" in r.json() and "tasks_etag" in r.json()
+    assert r.json()["prose_etag"] != r.json()["tasks_etag"]
+
+    r = client.get("/api/notes/etag?path=8d_split.md", headers={"Authorization": AUTH})
+    assert r.status_code == 200
+    assert "prose_etag" in r.json() and "tasks_etag" in r.json()
+
+
+def test_8d_typing_prose_while_popover_patches_task_no_conflict(client):
+    """Reproduces the user-visible "constant disk-changed" UX bug.
+
+    Sequence:
+      1. User opens a note (captures prose_etag P0, byte etag E0).
+      2. While they're typing, a popover ``PATCH /tasks/...`` rewrites
+         a task line on disk. Byte etag becomes E1, prose etag stays P0.
+      3. User saves their prose edits, sending ``if_match_prose: P0``.
+
+    Pre-8d: step 3 would 409 stale_write (E0 != E1) and the user would
+    be forced to reload, losing in-progress edits or accept a confirm
+    dialog.
+
+    Post-8d: step 3 succeeds (200) because the prose axis still
+    matches, and the popover task change is preserved via
+    ``merge_with_disk_tasks``.
+    """
+    body = (
+        "# 8d typing\n\n"
+        "@admin\n\n"
+        "- !task Touch me #id T-8DBB01 #owner @admin #status todo\n\n"
+        "original prose\n"
+    )
+    r = _put_8d(client, "8d_typing.md", body)
+    assert r.status_code == 200, r.text
+    p0 = r.json()["prose_etag"]
+
+    # Find the task in the DB-backed task list and patch it via the
+    # structured endpoint — same path the popover uses.
+    r = client.get("/api/tasks?q=Touch", headers={"Authorization": AUTH})
+    tasks = r.json()["tasks"]
+    assert tasks, r.text
+    tid = tasks[0]["id"]
+    r = client.patch(
+        f"/api/tasks/{tid}",
+        json={"status": "in-progress"},
+        headers={"Authorization": AUTH},
+    )
+    assert r.status_code == 200, r.text
+
+    # User's editor now writes their prose edit. Their copy of the task
+    # line is still the pre-popover version (status: todo) — that's the
+    # exact stale-task scenario 8d targets.
+    edited = (
+        "# 8d typing — EDITED HEADING\n\n"
+        "@admin\n\n"
+        "- !task Touch me #id T-8DBB01 #owner @admin #status todo\n\n"
+        "original prose, plus a typed-in line\n"
+    )
+    r = _put_8d(client, "8d_typing.md", edited, if_match_prose=p0)
+    assert r.status_code == 200, r.text
+    saved = r.json()
+    # Re-read to confirm the merged file: prose is the editor's, task
+    # status is the popover's.
+    r = client.get("/api/notes/etag?path=8d_typing.md", headers={"Authorization": AUTH})
+    full = client.get(
+        f"/api/notes/{saved['id']}", headers={"Authorization": AUTH}
+    ).json()["body_md"]
+    assert "EDITED HEADING" in full, full
+    assert "typed-in line" in full, full
+    assert "in-progress" in full, full
+
+
+def test_8d_genuine_prose_conflict_returns_stale_prose(client):
+    """If the prose axis itself drifted (e.g. another user edited the
+    free text on disk), 8d still surfaces a 409 — this time with
+    ``error: 'stale_prose'`` and the new ``current_prose_etag`` /
+    ``current_tasks_etag`` so the frontend can populate the recovery
+    dialog from the same response.
+    """
+    body = (
+        "# 8d conflict\n\n"
+        "@admin\n\n"
+        "- !task X #id T-8DCC01 #owner @admin #status todo\n\n"
+        "version A\n"
+    )
+    r = _put_8d(client, "8d_conflict.md", body)
+    assert r.status_code == 200, r.text
+    p0 = r.json()["prose_etag"]
+
+    # Simulate another writer touching the prose axis.
+    body_b = body.replace("version A", "version B")
+    r = _put_8d(client, "8d_conflict.md", body_b)
+    assert r.status_code == 200, r.text
+
+    # Original client still thinks prose is at P0 — server must reject.
+    body_c = body.replace("version A", "version C")
+    r = _put_8d(client, "8d_conflict.md", body_c, if_match_prose=p0)
+    assert r.status_code == 409, r.text
+    detail = r.json()["detail"]
+    assert detail["error"] == "stale_prose"
+    assert "current_prose_etag" in detail
+    assert "current_tasks_etag" in detail
+    assert detail["current_content"] is not None

--- a/VegaNotes/frontend/src/App.tsx
+++ b/VegaNotes/frontend/src/App.tsx
@@ -40,7 +40,18 @@ function ViewSwitcher({ selectedPath, setSelectedPath, draft, setDraft }: {
   }
 }
 
-type DraftEntry = { body: string; saved: string; savedAt: number; etag: string };
+type DraftEntry = {
+  body: string;
+  saved: string;
+  savedAt: number;
+  etag: string;
+  // Design 8d: track per-axis etags so the 5 s freshness poll can
+  // distinguish prose conflicts (must surface) from task-line drift
+  // (popover writes — silent merge), and the save path can use
+  // ``if_match_prose`` instead of byte-level ``If-Match``.
+  proseEtag: string;
+  tasksEtag: string;
+};
 type DraftMap = Record<string, DraftEntry>;
 
 function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
@@ -102,24 +113,33 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
   useEffect(() => {
     if (!selectedPath || !noteQuery.data) return;
     const fresh = noteQuery.data;
+    const proseEtag = fresh.prose_etag ?? "";
+    const tasksEtag = fresh.tasks_etag ?? "";
     setDraft((prev) => {
       const cur = prev[selectedPath];
       if (!cur) {
         return { ...prev, [selectedPath]: {
           body: fresh.body_md, saved: fresh.body_md,
           savedAt: Date.now(), etag: fresh.etag,
+          proseEtag, tasksEtag,
         }};
       }
       if (cur.body === cur.saved && cur.body !== fresh.body_md) {
         return { ...prev, [selectedPath]: {
           body: fresh.body_md, saved: fresh.body_md,
           savedAt: Date.now(), etag: fresh.etag,
+          proseEtag, tasksEtag,
         }};
       }
-      // Clean draft, body already matches — just refresh the etag in case
-      // a no-op write (e.g. whitespace normalization) bumped it server-side.
-      if (cur.body === cur.saved && cur.etag !== fresh.etag) {
-        return { ...prev, [selectedPath]: { ...cur, etag: fresh.etag } };
+      // Clean draft, body already matches — refresh etags in case a
+      // no-op write (whitespace normalization, popover task patch, etc)
+      // bumped them server-side.
+      if (cur.body === cur.saved && (
+        cur.etag !== fresh.etag ||
+        cur.proseEtag !== proseEtag ||
+        cur.tasksEtag !== tasksEtag
+      )) {
+        return { ...prev, [selectedPath]: { ...cur, etag: fresh.etag, proseEtag, tasksEtag } };
       }
       return prev;
     });
@@ -146,11 +166,26 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
 
   const flushSave = async (path: string, text: string) => {
     setStatus("saving");
-    const expected = draft[path]?.etag;
+    const cur = draft[path];
+    const expected = cur?.etag;
+    // Design 8d: if we have a prose-axis etag, prefer the prose-aware
+    // save path so the user's free-text edits don't 409 against
+    // popover-driven task-line writes that landed during the typing
+    // session.  Falls back to plain byte-level ``If-Match`` for legacy
+    // / non-editor callers (e.g. drafts opened before the etag was
+    // populated).
+    const ifMatchProse = cur?.proseEtag && cur.proseEtag.length > 0 ? cur.proseEtag : undefined;
     try {
-      const r = await api.saveNote(path, text, expected);
+      const r = await api.saveNote(path, text, expected, { ifMatchProse });
       setDraft((prev) => prev[path]
-        ? { ...prev, [path]: { ...prev[path], saved: text, savedAt: Date.now(), etag: r.etag } }
+        ? { ...prev, [path]: {
+            ...prev[path],
+            saved: text,
+            savedAt: Date.now(),
+            etag: r.etag,
+            proseEtag: r.prose_etag ?? prev[path].proseEtag,
+            tasksEtag: r.tasks_etag ?? prev[path].tasksEtag,
+          } }
         : prev);
       invalidateAfterSave(path);
       setStatus("saved");
@@ -160,8 +195,12 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
         // Surface a user-controlled recovery rather than letting the next
         // autosave silently clobber whichever side won the race.
         const detail = (e.body as { detail?: { error?: string;
-          current_content?: string; current_etag?: string } } | null)?.detail;
-        if (detail?.error === "stale_write" && typeof detail.current_etag === "string") {
+          current_content?: string; current_etag?: string;
+          current_prose_etag?: string; current_tasks_etag?: string } } | null)?.detail;
+        if (
+          (detail?.error === "stale_write" || detail?.error === "stale_prose")
+          && typeof detail.current_etag === "string"
+        ) {
           const reload = window.confirm(
             `${path} changed on disk since you opened it.\n\n` +
             `OK = reload disk content (your unsaved edits will be lost).\n` +
@@ -173,16 +212,23 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
               [path]: {
                 body: fresh, saved: fresh,
                 savedAt: Date.now(), etag: detail.current_etag!,
+                proseEtag: detail.current_prose_etag ?? "",
+                tasksEtag: detail.current_tasks_etag ?? "",
               },
             }));
             qcLocal.invalidateQueries({ queryKey: ["note", noteId] });
             setStatus("saved");
             return;
           }
-          // User chose to overwrite — adopt the disk etag so the next save
-          // will succeed. Their current `body` is preserved as-is.
+          // User chose to overwrite — adopt the disk etags so the next
+          // save will succeed. Their current `body` is preserved as-is.
           setDraft((prev) => prev[path]
-            ? { ...prev, [path]: { ...prev[path], etag: detail.current_etag! } }
+            ? { ...prev, [path]: {
+                ...prev[path],
+                etag: detail.current_etag!,
+                proseEtag: detail.current_prose_etag ?? prev[path].proseEtag,
+                tasksEtag: detail.current_tasks_etag ?? prev[path].tasksEtag,
+              } }
             : prev);
           setStatus("idle");
           return;
@@ -239,8 +285,31 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
         if (cancelled) return;
         const cur = draftRef.current[selectedPath];
         if (!cur) return;
-        if (r.etag === cur.etag) {
-          // Disk still matches what we have — clear any stale banner.
+        // Design 8d: only treat *prose-axis* drift as a real freshness
+        // event for the editor.  Task-line drift (popover writes) is
+        // resolved silently at save time via ``merge_with_disk_tasks``,
+        // so it shouldn't trip the conflict banner or force a refetch
+        // mid-typing.  Compare on prose etag when available, fall back
+        // to byte-level etag for older backends.
+        const curProse = cur.proseEtag || cur.etag;
+        const diskProse = r.prose_etag ?? r.etag;
+        const curTasks = cur.tasksEtag;
+        const diskTasks = r.tasks_etag ?? "";
+        if (curProse === diskProse) {
+          // Prose stable.  If only the task axis drifted *and* the
+          // buffer is clean, silently refresh so the editor picks up
+          // popover-driven task-line edits without flicker.
+          if (cur.body === cur.saved && curTasks && diskTasks && curTasks !== diskTasks) {
+            if (noteId != null) qcLocal.invalidateQueries({ queryKey: ["note", noteId] });
+          } else if (cur.body === cur.saved && curTasks && diskTasks && curTasks === diskTasks) {
+            // Fully in sync — also patch any drifted byte-level etag so
+            // the next save's ``If-Match`` doesn't 409.
+            if (cur.etag !== r.etag) {
+              setDraft((prev) => prev[selectedPath]
+                ? { ...prev, [selectedPath]: { ...prev[selectedPath], etag: r.etag } }
+                : prev);
+            }
+          }
           if (diskConflict?.path === selectedPath) setDiskConflict(null);
           return;
         }
@@ -249,7 +318,7 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
           if (noteId != null) qcLocal.invalidateQueries({ queryKey: ["note", noteId] });
           if (diskConflict?.path === selectedPath) setDiskConflict(null);
         } else {
-          // Both sides moved → surface the banner.
+          // Both sides' prose moved → surface the banner.
           setDiskConflict({ path: selectedPath, diskEtag: r.etag });
         }
       } catch { /* network blip — ignore */ }
@@ -269,6 +338,8 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
         saved: prev[selectedPath]?.saved ?? v,
         savedAt: prev[selectedPath]?.savedAt ?? 0,
         etag: prev[selectedPath]?.etag ?? "",
+        proseEtag: prev[selectedPath]?.proseEtag ?? "",
+        tasksEtag: prev[selectedPath]?.tasksEtag ?? "",
       },
     }));
   };
@@ -305,6 +376,8 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
         [selectedPath]: {
           body: fresh.body_md, saved: fresh.body_md,
           savedAt: Date.now(), etag: fresh.etag,
+          proseEtag: fresh.prose_etag ?? "",
+          tasksEtag: fresh.tasks_etag ?? "",
         },
       }));
       qcLocal.invalidateQueries({ queryKey: ["note", noteId] });
@@ -343,6 +416,8 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
           body: r.body_md, saved: r.body_md,
           savedAt: Date.now(),
           etag: fresh?.etag ?? "",
+          proseEtag: fresh?.prose_etag ?? "",
+          tasksEtag: fresh?.tasks_etag ?? "",
         },
       }));
       qcLocal.invalidateQueries({ queryKey: ["notes"] });
@@ -373,7 +448,11 @@ function EditorPane({ selectedPath, setSelectedPath, draft, setDraft }: {
       const n = await api.note(meta.id);
       setDraft((prev) => ({
         ...prev,
-        [selectedPath]: { body: n.body_md, saved: n.body_md, savedAt: Date.now(), etag: n.etag },
+        [selectedPath]: {
+          body: n.body_md, saved: n.body_md, savedAt: Date.now(), etag: n.etag,
+          proseEtag: n.prose_etag ?? "",
+          tasksEtag: n.tasks_etag ?? "",
+        },
       }));
       qcLocal.invalidateQueries({ queryKey: ["note", meta.id] });
       qcLocal.invalidateQueries({ queryKey: ["notes"] });

--- a/VegaNotes/frontend/src/api/client.ts
+++ b/VegaNotes/frontend/src/api/client.ts
@@ -145,18 +145,36 @@ export interface ProjectMember {
 
 export const api = {
   notes: () => req<{ id: number; path: string; title: string }[]>("/notes"),
-  note:  (id: number) => req<{ id: number; path: string; title: string; body_md: string; etag: string }>(`/notes/${id}`),
+  note:  (id: number) => req<{ id: number; path: string; title: string; body_md: string; etag: string; prose_etag?: string; tasks_etag?: string }>(`/notes/${id}`),
   noteEtag: (path: string) =>
-    req<{ path: string; etag: string; mtime: number }>(
+    req<{ path: string; etag: string; prose_etag?: string; tasks_etag?: string; mtime: number }>(
       `/notes/etag?path=${encodeURIComponent(path)}`,
     ),
-  saveNote: (path: string, body_md: string, ifMatch?: string) =>
-    req<{ id: number; path: string; etag: string }>("/notes", {
+  saveNote: (
+    path: string,
+    body_md: string,
+    ifMatch?: string,
+    opts?: { ifMatchProse?: string },
+  ) =>
+    req<{
+      id: number;
+      path: string;
+      etag: string;
+      prose_etag?: string;
+      tasks_etag?: string;
+    }>("/notes", {
       method: "PUT",
-      body: JSON.stringify({ path, body_md }),
-      // Optimistic concurrency: backend safe_write compares this against the
-      // file's current sha256 etag and returns 409 stale_write on mismatch.
-      // `""` means "I expect this path to be new" (the create case).
+      // Design 8d: when ifMatchProse is supplied the backend gates the
+      // write on the prose-axis etag and merges live disk task lines on
+      // top of the incoming prose. This stops popover ``PATCH /tasks/...``
+      // writes from triggering false-positive 409s while the user is
+      // typing. Plain `ifMatch` (byte-level) still works for legacy /
+      // non-editor callers.
+      body: JSON.stringify({
+        path,
+        body_md,
+        ...(opts?.ifMatchProse !== undefined ? { if_match_prose: opts.ifMatchProse } : {}),
+      }),
       headers: ifMatch !== undefined ? { "If-Match": ifMatch } : {},
     }),
   deleteNote: (id: number) => req(`/notes/${id}`, { method: "DELETE" }),


### PR DESCRIPTION
Decouples free-text editor writes from popover/PATCH writes so that typing in the .md editor stops triggering false-positive 409 conflict banners every time a popover patches a task line on disk.

## Why
The 5 s freshness poll plus byte-level sha256 etag plus popover \`PATCH /tasks/...\` writes interacted destructively: any status/owner/eta/note edit through the popover changed the file's byte hash, so the editor's poll saw "disk moved" and either silently refetched (clean buffer) or banner-flashed a conflict (dirty buffer). With multiple users on the same weekly file this happened every few seconds, making direct .md editing nearly unusable.

## What
A markdown buffer is now treated as two independent axes:

- \`prose_etag\` — sha256 of all non-task lines (free text, headings, top-level @owner / #project context, blank lines).
- \`tasks_etag\` — sha256 of all task-classified lines (\`!task\`/\`!AR\` declarations, ref rows, indented \`#note\` continuations).

### Concurrency contract
- Editor poll compares \`prose_etag\` instead of byte etag. Tasks-only drift (the popover's normal behaviour) silently invalidates the React-Query cache on a clean buffer and is ignored on a dirty one.
- Editor save sends \`if_match_prose\`. The server gates the write on the prose axis, then runs \`merge_with_disk_tasks\` to overlay disk task lines onto the editor's prose buffer — popover edits accumulated during typing are preserved.
- Genuine prose-vs-prose drift still 409s, now with \`error: 'stale_prose'\` and the new \`current_prose_etag\` / \`current_tasks_etag\` so the recovery dialog is fully populated from one response.

## Backend
- \`app/parser/parser.py\`: \`classify_lines(md) -> list[str]\`.
- \`app/parser/__init__.py\`: re-export.
- \`app/safe_io.py\`: \`etag_components(md_text)\` returns \`{'prose', 'tasks'}\`.
- \`app/markdown_ops.py\`: \`_split_into_blocks\`, \`merge_with_disk_tasks\` — uuid-keyed task overlay (popover wins on the task axis, editor wins on the prose axis, popover-deleted tasks dropped, popover-added tasks appended).
- \`app/api/__init__.py\`: \`GET /notes/etag\` and \`GET /notes/{id}\` return \`prose_etag\` + \`tasks_etag\`. \`PUT /notes\` accepts optional \`if_match_prose\`; on match → merge; on mismatch → 409 \`stale_prose\`. Existing byte-level \`If-Match\` continues to work for legacy callers. \`stale_write\` 409 also gains the new etag fields.

## Frontend
- \`api/client.ts\`: \`saveNote(..., { ifMatchProse })\`. \`note\` and \`noteEtag\` return types pick up the two new fields.
- \`App.tsx\`: \`DraftEntry\` extended with \`proseEtag\` / \`tasksEtag\`. \`flushSave\` prefers the prose-aware save path. \`tick()\` (5 s poll) compares prose etags; tasks-only drift on a clean buffer triggers a silent cache invalidation; dirty buffers only banner on prose drift. The 409 recovery dialog handles both \`stale_write\` and \`stale_prose\`.

## Tests
- \`test_8d_get_endpoints_return_split_etags\` — both etag fields are present on \`GET /notes/etag\` and \`GET /notes/{id}\`.
- \`test_8d_typing_prose_while_popover_patches_task_no_conflict\` — end-to-end: open note, popover \`PATCH /tasks/...\` flips status while editor's prose changes; save with \`if_match_prose\` from the open-time snapshot succeeds and the merged file contains both the editor's prose and the popover's task status.
- \`test_8d_genuine_prose_conflict_returns_stale_prose\` — both sides edit prose: 409 \`stale_prose\` with the new etag fields.

Run: \`pytest tests/ --deselect tests/api/test_api.py::test_create_and_query --deselect tests/parser/test_parser.py::test_golden[sprint14] --deselect tests/test_watcher.py::test_polling_awatch_observes_external_change\` → 383 passed (3 deselected are pre-existing clock/poll-dependent flakes unrelated to this change).

Also bundles a small phonebook-data commit (\`gbandana\` + \`kushwanth\` alias) needed to canonicalize 13 tasks that were creating an orphan \`User\` row.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>