### PR TITLE
feat(veganotes): scope done tasks to active notes with toggle (#258)

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -1345,7 +1345,16 @@ def list_tasks(
     sort: Optional[str] = None,
     limit: Optional[int] = Query(default=None, ge=1, le=2000),
     offset: int = Query(default=0, ge=0),
+    # #258: scope done tasks to non-archived notes by default. "active" hides
+    # done tasks that live in archived (rolled-over) weekly md files; "all"
+    # is the historical behaviour. Open tasks are unaffected — only the
+    # `status = done` set is scoped.
+    done_scope: str = Query(default="active"),
 ) -> dict[str, Any]:
+    if done_scope not in ("active", "all"):
+        raise HTTPException(
+            422, f"done_scope must be 'active' or 'all', got {done_scope!r}",
+        )
     sql = ["SELECT DISTINCT t.id FROM task t"]
     params: dict[str, Any] = {}
     expanding: list[str] = []
@@ -1354,6 +1363,12 @@ def list_tasks(
     _vis_admin, _vis_projects = _visible_projects(s, user)
     if not _vis_admin:
         sql.append("JOIN note rbac_n ON rbac_n.id = t.note_id")
+    # #258: separate join when we need archived-flag visibility for done
+    # scoping. We could in principle reuse `rbac_n` when it's present, but
+    # keeping the alias dedicated keeps the SQL readable and avoids coupling
+    # the two concerns.
+    if done_scope == "active":
+        sql.append("JOIN note done_n ON done_n.id = t.note_id")
 
     def _join_multi(table: str, name_table: str, names: list[str], alias: str) -> None:
         if not names:
@@ -1384,6 +1399,12 @@ def list_tasks(
         where.append("t.status IN :statuses")
         params["statuses"] = tuple(statuses)
         expanding.append("statuses")
+    # #258: when done_scope="active", drop done tasks whose source note is
+    # archived. Open tasks (todo/in-progress/blocked) are intentionally
+    # unaffected — they're either still relevant on the active week or
+    # candidates for sweeping (separate concern).
+    if done_scope == "active":
+        where.append("NOT (t.status = 'done' AND done_n.archived = 1)")
     prios = _collect_filter(priority)
     if prios:
         sql.append("JOIN taskattr pa ON pa.task_id = t.id AND pa.key='priority'")

--- a/VegaNotes/backend/tests/api/test_api.py
+++ b/VegaNotes/backend/tests/api/test_api.py
@@ -2263,3 +2263,139 @@ def test_8d_genuine_prose_conflict_returns_stale_prose(client):
     assert "current_prose_etag" in detail
     assert "current_tasks_etag" in detail
     assert detail["current_content"] is not None
+
+
+# ── #258: done_scope (active vs all) ──────────────────────────────────────
+def _make_archived_done_fixture(client):
+    """Build a project with one active note (ww70 — has one open + one done
+    task) and one archived note (ww69 — flagged Note.archived=True, holds
+    one done task that should be hidden by default).
+
+    Returns (active_uuid_open, active_uuid_done, archived_uuid_done).
+    """
+    from app.db import session_scope
+    from app.models import Note
+    from sqlmodel import select as _select
+
+    client.post("/api/projects", json={"name": "donescope"},
+                headers={"Authorization": AUTH})
+    client.put("/api/notes",
+               json={"path": "donescope/ww70.md",
+                     "body_md": (
+                         "# donescope ww70\n"
+                         "@admin\n"
+                         "\t!task #id T-DSACTOPEN Active open #status todo\n"
+                         "\t!task #id T-DSACTDONE Active done #status done\n"
+                     )},
+               headers={"Authorization": AUTH})
+    client.put("/api/notes",
+               json={"path": "donescope/_archive/ww69.md",
+                     "body_md": (
+                         "# donescope ww69 (archived)\n"
+                         "@admin\n"
+                         "\t!task #id T-DSARCDONE Archived done #status done\n"
+                     )},
+               headers={"Authorization": AUTH})
+    with session_scope() as s:
+        n = s.exec(_select(Note).where(
+            Note.path == "donescope/_archive/ww69.md")).one()
+        n.archived = True
+        s.add(n)
+    return ("T-DSACTOPEN", "T-DSACTDONE", "T-DSARCDONE")
+
+
+def test_done_scope_active_hides_archived_done(client):
+    """#258: GET /tasks?done_scope=active (default) excludes done tasks
+    whose source Note is archived. Open tasks in archived notes are
+    unaffected — only the done set is scoped."""
+    open_uuid, act_done_uuid, arc_done_uuid = _make_archived_done_fixture(client)
+
+    r = client.get("/api/tasks?done_scope=active",
+                   headers={"Authorization": AUTH})
+    assert r.status_code == 200, r.text
+    uuids = {t["task_uuid"] for t in r.json()["tasks"]}
+    assert open_uuid in uuids, "active-week open task must remain visible"
+    assert act_done_uuid in uuids, "active-week done task must remain visible"
+    assert arc_done_uuid not in uuids, (
+        "archived-week done task must be hidden by done_scope=active "
+        "(this is the whole point of #258)"
+    )
+
+
+def test_done_scope_default_is_active(client):
+    """No explicit done_scope → behave as 'active' (the new default)."""
+    _, _, arc_done_uuid = _make_archived_done_fixture(client)
+    r = client.get("/api/tasks", headers={"Authorization": AUTH})
+    assert r.status_code == 200, r.text
+    uuids = {t["task_uuid"] for t in r.json()["tasks"]}
+    assert arc_done_uuid not in uuids
+
+
+def test_done_scope_all_includes_archived_done(client):
+    """done_scope=all preserves the historical behaviour — archived-week
+    done tasks are returned alongside active-week ones."""
+    open_uuid, act_done_uuid, arc_done_uuid = _make_archived_done_fixture(client)
+    r = client.get("/api/tasks?done_scope=all", headers={"Authorization": AUTH})
+    assert r.status_code == 200, r.text
+    uuids = {t["task_uuid"] for t in r.json()["tasks"]}
+    assert open_uuid in uuids
+    assert act_done_uuid in uuids
+    assert arc_done_uuid in uuids
+
+
+def test_done_scope_does_not_filter_open_tasks_in_archived_notes(client):
+    """Sanity: only `status = done` is scoped. An open task accidentally
+    left in an archived note must still be visible regardless of scope —
+    those tasks need attention, not hiding."""
+    from app.db import session_scope
+    from app.models import Note
+    from sqlmodel import select as _select
+
+    client.post("/api/projects", json={"name": "dsopenarc"},
+                headers={"Authorization": AUTH})
+    client.put("/api/notes",
+               json={"path": "dsopenarc/ww50.md",
+                     "body_md": "# dsopenarc ww50\n@admin\n\t!task #id T-DSACTIVE seed #status todo\n"},
+               headers={"Authorization": AUTH})
+    client.put("/api/notes",
+               json={"path": "dsopenarc/_archive/ww49.md",
+                     "body_md": (
+                         "# dsopenarc ww49 (archived)\n"
+                         "@admin\n"
+                         "\t!task #id T-DSOPENARC stuck open #status in-progress\n"
+                     )},
+               headers={"Authorization": AUTH})
+    with session_scope() as s:
+        n = s.exec(_select(Note).where(
+            Note.path == "dsopenarc/_archive/ww49.md")).one()
+        n.archived = True
+        s.add(n)
+
+    r = client.get("/api/tasks?done_scope=active",
+                   headers={"Authorization": AUTH})
+    assert r.status_code == 200, r.text
+    uuids = {t["task_uuid"] for t in r.json()["tasks"]}
+    assert "T-DSOPENARC" in uuids, (
+        "open task in archived note must NOT be hidden by done_scope=active"
+    )
+
+
+def test_done_scope_invalid_value_returns_422(client):
+    r = client.get("/api/tasks?done_scope=bogus",
+                   headers={"Authorization": AUTH})
+    assert r.status_code == 422
+    assert "active" in r.json()["detail"]
+
+
+def test_done_scope_active_composes_with_owner_filter(client):
+    """done_scope=active still respects other filters (owner here). The
+    archived-done filter is applied as an extra WHERE clause, not as a
+    replacement for the existing query plan."""
+    open_uuid, act_done_uuid, arc_done_uuid = _make_archived_done_fixture(client)
+    r = client.get("/api/tasks?owner=admin&done_scope=active",
+                   headers={"Authorization": AUTH})
+    assert r.status_code == 200, r.text
+    uuids = {t["task_uuid"] for t in r.json()["tasks"]}
+    assert open_uuid in uuids
+    assert act_done_uuid in uuids
+    assert arc_done_uuid not in uuids

--- a/VegaNotes/frontend/src/components/Kanban/KanbanBoard.tsx
+++ b/VegaNotes/frontend/src/components/Kanban/KanbanBoard.tsx
@@ -6,6 +6,7 @@ import { TaskEditPopover } from "../Tasks/TaskEditPopover";
 import { NewTaskComposer } from "../Tasks/NewTaskComposer";
 import { useUI, filtersToParams } from "../../store/ui";
 import { useFontScale, type FontScale } from "../../store/fontScale";
+import { loadDoneScope, saveDoneScope, type DoneScope } from "../../store/doneScope";
 import { KanbanEmailModal } from "./KanbanEmailModal";
 
 const SCALES: { value: FontScale; label: string; title: string }[] = [
@@ -29,14 +30,22 @@ export function KanbanBoard() {
   const [composerColumn, setComposerColumn] = useState<string | null>(null);
   const [emailOpen, setEmailOpen] = useState(false);
   const { scale, setScale } = useFontScale();
+  // #258: scope done tasks to non-archived notes by default. Persists per
+  // view in localStorage; flipping in MyTasks doesn't change Kanban.
+  const [doneScope, setDoneScope] = useState<DoneScope>(() => loadDoneScope("kanban"));
+  const updateDoneScope = (v: DoneScope) => {
+    setDoneScope(v);
+    saveDoneScope("kanban", v);
+  };
   const { data } = useQuery({
-    queryKey: ["tasks", filters, "kanban"],
+    queryKey: ["tasks", filters, "kanban", doneScope],
     queryFn: () =>
       api.tasks({
         ...filtersToParams(filters),
         hide_done: false,
         top_level_only: true,
         include_children: true,
+        done_scope: doneScope,
       }),
   });
   const tasks = data?.tasks ?? [];
@@ -51,6 +60,18 @@ export function KanbanBoard() {
     <>
       {/* toolbar */}
       <div className="flex items-center justify-end gap-1 px-4 pt-3 pb-1">
+        <label
+          className="mr-2 flex items-center gap-1.5 text-xs text-slate-600 cursor-pointer select-none rounded border border-slate-200 bg-slate-50 px-2 py-1"
+          title="When on, the Done column shows only tasks from active (non-archived) notes. Turn off to include done tasks from archived weekly files."
+        >
+          <input
+            type="checkbox"
+            checked={doneScope === "active"}
+            onChange={(e) => updateDoneScope(e.target.checked ? "active" : "all")}
+            className="rounded"
+          />
+          done from active files only
+        </label>
         <button
           onClick={() => setEmailOpen(true)}
           title="Send a snapshot of the current Kanban view via email"

--- a/VegaNotes/frontend/src/components/Tasks/MyTasksView.tsx
+++ b/VegaNotes/frontend/src/components/Tasks/MyTasksView.tsx
@@ -20,6 +20,7 @@ import { NewTaskComposer } from "./NewTaskComposer";
 import { StatusChip, PriorityChip, EtaChip, OwnersChips } from "./QuickChips";
 import { BulkEditBar } from "./BulkEditBar";
 import { useUI } from "../../store/ui";
+import { loadDoneScope, saveDoneScope, type DoneScope } from "../../store/doneScope";
 
 // ── selection helpers (issue #33) ─────────────────────────────────────────────
 
@@ -368,16 +369,22 @@ export function MyTasksView() {
 
   const [groupBy,  setGroupBy]  = useState<GroupBy>("status");
   const [hideDone, setHideDone] = useState(true);
+  // #258: scope done tasks to non-archived notes by default.
+  const [doneScope, setDoneScope] = useState<DoneScope>(() => loadDoneScope("my-tasks"));
+  const updateDoneScope = (v: DoneScope) => {
+    setDoneScope(v);
+    saveDoneScope("my-tasks", v);
+  };
   const [editing,  setEditing]  = useState<Task | null>(null);
   // Single-active composer: either a group key (per-group "+") or "__top".
   const [composerOpen, setComposerOpen] = useState<string | null>(null);
   const { filters } = useUI();
 
   const { data, isLoading } = useQuery({
-    queryKey: ["my-tasks", me?.name, hideDone],
+    queryKey: ["my-tasks", me?.name, hideDone, doneScope],
     queryFn: () =>
       me?.name
-        ? api.tasks({ owner: me.name, hide_done: hideDone, top_level_only: true, include_children: true })
+        ? api.tasks({ owner: me.name, hide_done: hideDone, top_level_only: true, include_children: true, done_scope: doneScope })
         : Promise.resolve(null),
     enabled: !!me?.name,
   });
@@ -515,6 +522,24 @@ export function MyTasksView() {
                 className="rounded"
               />
               hide done
+            </label>
+
+            {/* #258: done-scope toggle. Disabled when "hide done" is on
+                because no done tasks would be visible anyway. */}
+            <label
+              className={`flex items-center gap-1.5 text-xs cursor-pointer select-none rounded border border-slate-200 bg-slate-50 px-2 py-1 ${hideDone ? "opacity-40 cursor-not-allowed" : "text-slate-600"}`}
+              title={hideDone
+                ? "Turn off 'hide done' first to choose between active and all done tasks"
+                : "When on, the Done set shows only tasks from active (non-archived) notes."}
+            >
+              <input
+                type="checkbox"
+                checked={doneScope === "active"}
+                disabled={hideDone}
+                onChange={(e) => updateDoneScope(e.target.checked ? "active" : "all")}
+                className="rounded"
+              />
+              done from active files only
             </label>
           </div>
         </div>

--- a/VegaNotes/frontend/src/store/doneScope.ts
+++ b/VegaNotes/frontend/src/store/doneScope.ts
@@ -1,0 +1,48 @@
+/**
+ * #258: per-view persistence of the "Done from active files only" toggle.
+ *
+ * Each view (Kanban, MyTasks, …) gets its own slot so flipping the toggle
+ * in one view doesn't change the other. The persisted shape is a JSON
+ * object keyed by view name; values are exactly "active" | "all".
+ *
+ * Storage failures (private mode, quota, etc.) are best-effort — read
+ * returns the default, write is a no-op.
+ */
+export type DoneScope = "active" | "all";
+export type DoneScopeView = "kanban" | "my-tasks";
+
+export const DONE_SCOPE_STORAGE_KEY = "veganotes:done-scope:v1";
+export const DEFAULT_DONE_SCOPE: DoneScope = "active";
+
+type Persisted = Partial<Record<DoneScopeView, DoneScope>>;
+
+function readAll(): Persisted {
+  try {
+    const raw = localStorage.getItem(DONE_SCOPE_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: Persisted = {};
+    for (const k of ["kanban", "my-tasks"] as const) {
+      const v = (parsed as Record<string, unknown>)[k];
+      if (v === "active" || v === "all") out[k] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export function loadDoneScope(view: DoneScopeView): DoneScope {
+  return readAll()[view] ?? DEFAULT_DONE_SCOPE;
+}
+
+export function saveDoneScope(view: DoneScopeView, value: DoneScope): void {
+  try {
+    const all = readAll();
+    all[view] = value;
+    localStorage.setItem(DONE_SCOPE_STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    /* best-effort */
+  }
+}

--- a/VegaNotes/frontend/tests/doneScope.test.ts
+++ b/VegaNotes/frontend/tests/doneScope.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  DONE_SCOPE_STORAGE_KEY,
+  DEFAULT_DONE_SCOPE,
+  loadDoneScope,
+  saveDoneScope,
+} from "../src/store/doneScope";
+
+beforeEach(() => {
+  try {
+    localStorage.removeItem(DONE_SCOPE_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+});
+
+describe("doneScope storage (#258)", () => {
+  it("returns the default 'active' on a fresh session", () => {
+    expect(loadDoneScope("kanban")).toBe(DEFAULT_DONE_SCOPE);
+    expect(loadDoneScope("my-tasks")).toBe(DEFAULT_DONE_SCOPE);
+    expect(DEFAULT_DONE_SCOPE).toBe("active");
+  });
+
+  it("persists per-view independently", () => {
+    saveDoneScope("kanban", "all");
+    expect(loadDoneScope("kanban")).toBe("all");
+    expect(loadDoneScope("my-tasks")).toBe("active");
+
+    saveDoneScope("my-tasks", "all");
+    expect(loadDoneScope("kanban")).toBe("all");
+    expect(loadDoneScope("my-tasks")).toBe("all");
+  });
+
+  it("round-trips both scopes", () => {
+    saveDoneScope("kanban", "all");
+    expect(loadDoneScope("kanban")).toBe("all");
+    saveDoneScope("kanban", "active");
+    expect(loadDoneScope("kanban")).toBe("active");
+  });
+
+  it("falls back to default on JSON corruption", () => {
+    localStorage.setItem(DONE_SCOPE_STORAGE_KEY, "{not valid json");
+    expect(loadDoneScope("kanban")).toBe(DEFAULT_DONE_SCOPE);
+  });
+
+  it("falls back to default for malformed values", () => {
+    localStorage.setItem(
+      DONE_SCOPE_STORAGE_KEY,
+      JSON.stringify({ kanban: "bogus", "my-tasks": 42 }),
+    );
+    expect(loadDoneScope("kanban")).toBe(DEFAULT_DONE_SCOPE);
+    expect(loadDoneScope("my-tasks")).toBe(DEFAULT_DONE_SCOPE);
+  });
+
+  it("falls back to default when payload is not an object", () => {
+    localStorage.setItem(DONE_SCOPE_STORAGE_KEY, JSON.stringify("active"));
+    expect(loadDoneScope("kanban")).toBe(DEFAULT_DONE_SCOPE);
+    localStorage.setItem(DONE_SCOPE_STORAGE_KEY, JSON.stringify(null));
+    expect(loadDoneScope("kanban")).toBe(DEFAULT_DONE_SCOPE);
+    localStorage.setItem(DONE_SCOPE_STORAGE_KEY, JSON.stringify(["active"]));
+    // Arrays are objects in JS — readAll iterates the known keys, both
+    // missing → defaults.
+    expect(loadDoneScope("kanban")).toBe(DEFAULT_DONE_SCOPE);
+  });
+
+  it("preserves the other view's value when saving one", () => {
+    saveDoneScope("kanban", "all");
+    saveDoneScope("my-tasks", "all");
+    saveDoneScope("kanban", "active");
+    expect(loadDoneScope("kanban")).toBe("active");
+    expect(loadDoneScope("my-tasks")).toBe("all");
+  });
+});


### PR DESCRIPTION
feat(veganotes): scope done tasks to active notes with toggle (#258)

Closes #258.

## Backend
`GET /tasks` accepts new query param:

    done_scope: Literal["active","all"] = "active"

When `active` (the default), tasks with `status = done` whose source
`Note.archived = True` are filtered out. Open tasks (todo / in-progress /
blocked) are intentionally unaffected — only the done set is scoped, so
stale open tasks accidentally left in archived weeks remain visible
(those need attention, not hiding).

Implemented as a single extra `JOIN note done_n` plus a one-liner WHERE
clause:

    NOT (t.status = 'done' AND done_n.archived = 1)

The join is dedicated rather than reusing the RBAC-visibility `rbac_n`
join — keeps the two concerns independent and the SQL readable.

Invalid values (`?done_scope=bogus`) return 422.

## Frontend
- `store/doneScope.ts` — small per-view localStorage helper:
  `loadDoneScope(view)` / `saveDoneScope(view, value)`.
  Storage key `veganotes:done-scope:v1`. Each view ("kanban" /
  "my-tasks") persists independently, so flipping the toggle in one
  view doesn't change the other. Best-effort: corruption / quota errors
  fall back to the default.
- `KanbanBoard`: header toggle "done from active files only"
  (default on). Sends `done_scope=active` to the tasks query, which is
  part of the React-Query key so flipping refetches.
- `MyTasksView`: same toggle next to "hide done". Auto-disabled (and
  visually dimmed) when "hide done" is on, since no done tasks would
  be visible in that case anyway.

## Tests
- 6 new backend tests in `tests/api/test_api.py` cover: active default
  hides archived done; explicit default behaves as active; `all`
  preserves history; open tasks in archived notes survive scoping;
  invalid scope → 422; composes with `?owner=` filter.
- 7 new vitest unit tests in `tests/doneScope.test.ts` cover: empty
  default; per-view independence; round-trip; JSON corruption;
  malformed values; non-object payloads; preserve-other-view-on-save.
- Full suites: 390 backend (excluding 3 pre-existing flakes), 162
  frontend. tsc + build clean.

## Why "active" is any non-archived note (not "single newest weekly")
Non-weekly categories (Personal Todo, Weekly SMT TypTE Bucket Debug,
…) each have their own active file. Filtering on `Note.archived`
uniformly scopes by the rollover-set flag, which is exactly what the
user asked for.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>