### PR TITLE
fix(veganotes): preserve top-level done declarations in archive (#260)

### DIFF
--- a/VegaNotes/backend/app/markdown_ops.py
+++ b/VegaNotes/backend/app/markdown_ops.py
@@ -168,6 +168,12 @@ def strip_top_level_done_tasks(md: str) -> str:
     historical context.
 
     Used by the new archive-style rollover (#251 follow-up).
+
+    Reminder on rollup semantics: ``t.status`` here is the rolled-up status
+    from :func:`_rollup_to_parents`. A literally-``#status done`` parent
+    that still has an open AR child is downgraded to ``in-progress`` and
+    is therefore kept by this function — open sub-items survive into the
+    next week with their parent (#260).
     """
     from .parser import parse
     parsed = parse(md)
@@ -249,9 +255,15 @@ def roll_to_next_week(
     nxt = cur + 1
     # 1. Inject missing IDs first so both files share the canonical IDs.
     patched_source, _ = inject_missing_ids(md)
-    # 2. New (next-week) file: drop only top-level done blocks; keep open
-    #    parents' indent blocks intact (so done children of open parents
-    #    move with their parent).  Then bump prose ww references.
+    # 2. New (next-week) file: drop only top-level done blocks. Done ARs
+    #    that live under an OPEN parent ride along with their parent so
+    #    the active week keeps the audit trail of completed sub-items
+    #    against still-open work (per user request, #260).
+    #    A "done" parent in this rollup-aware view means EVERY descendant
+    #    is also done (otherwise _rollup_to_parents downgrades the parent
+    #    to in-progress). So this rule equals: "drop a done leaf or a
+    #    fully-completed top-level subtree; keep any AR whose top-level
+    #    parent is still open".
     new_pruned = strip_top_level_done_tasks(patched_source)
     new_body = _bump_ww_outside_eta(new_pruned, cur, nxt)
     new_base = bump_ww(basename, cur, nxt)
@@ -552,9 +564,16 @@ def _replace_top_level_open_with_refs(md: str) -> str:
     Identifies top-level vs nested via the parser's ``parent_slug``:
     ``parent_slug is None`` means the task has no preceding shallower-indent
     task, regardless of whether bullets are mixed.
+
+    Skip-block pivots are stored in :func:`_line_indent` units (column
+    count) so they're directly comparable with the per-line indent of the
+    walker. Mixing parser-level units with line-column units used to swallow
+    every later top-level row beyond the first open one (issue #260, bug
+    #2) — a real data-loss path for top-level done declarations.
     """
     from .parser import parse
     parsed = parse(md)
+    lines = md.splitlines(keepends=True)
     open_top: dict[int, dict] = {}
     for t in parsed.get("tasks", []):
         if t.get("parent_slug") is not None:
@@ -565,14 +584,16 @@ def _replace_top_level_open_with_refs(md: str) -> str:
         if not rid:
             continue
         line_no = t.get("line")
-        if not isinstance(line_no, int):
+        if not isinstance(line_no, int) or not (0 <= line_no < len(lines)):
             continue
         open_top[line_no] = {
             "kind": t.get("kind", "task"),
-            "indent": t.get("indent", 0),
+            # Use line-column indent so the comparator below is in the
+            # same unit (#260 bug #2). Was previously t.get("indent", 0)
+            # which is parser-level units, off by 2x for tab indents.
+            "indent": _line_indent(lines[line_no]),
             "ref_id": rid,
         }
-    lines = md.splitlines(keepends=True)
     out: list[str] = []
     skip_indent: int | None = None
     for i, raw in enumerate(lines):

--- a/VegaNotes/backend/tests/api/test_api.py
+++ b/VegaNotes/backend/tests/api/test_api.py
@@ -2399,3 +2399,63 @@ def test_done_scope_active_composes_with_owner_filter(client):
     assert open_uuid in uuids
     assert act_done_uuid in uuids
     assert arc_done_uuid not in uuids
+
+# ── #260: rollover (POST /api/notes/next-week) ───────────────────────────
+def test_260_rollover_archive_has_done_blocks_active_drops_done_top_levels(client):
+    """Issue #260: the previous indent-unit bug in
+    ``_replace_top_level_open_with_refs`` caused every top-level row past
+    the first open task to be dropped from the archive (data loss). Post
+    fix, top-level done declarations are preserved in the archive while
+    being absent from the active week."""
+    client.post("/api/projects", json={"name": "rollbug260"},
+                headers={"Authorization": AUTH})
+    body = (
+        "# weekly ww30\n"
+        "@admin\n"
+        "\t!task #id T-RB260OP Open parent\n"
+        "\t\t!AR #id T-RB260OAR open ar #status todo\n"
+        "\t\t!AR #id T-RB260DAR1 done ar under open parent #status done\n"
+        "\t!task #id T-RB260DTOP Done top-level standalone #status done\n"
+        "\t!task #id T-RB260DPAR Done parent with done kids #status done\n"
+        "\t\t!AR #id T-RB260DAR2 done ar #status done\n"
+    )
+    r = client.put("/api/notes",
+                   json={"path": "rollbug260/weekly ww30.md", "body_md": body},
+                   headers={"Authorization": AUTH})
+    assert r.status_code == 200, r.text
+
+    r = client.post("/api/notes/next-week",
+                    json={"path": "rollbug260/weekly ww30.md"},
+                    headers={"Authorization": AUTH})
+    assert r.status_code == 200, r.text
+    new_path = r.json()["path"]
+    archive_path = r.json()["archived_path"]
+    assert new_path == "rollbug260/weekly ww31.md"
+
+    new_disk = (DATA / "notes" / new_path).read_text(encoding="utf-8")
+    arch_disk = (DATA / "notes" / archive_path).read_text(encoding="utf-8")
+
+    # Active week: open parent + all its ARs (open and done) survive;
+    # top-level done blocks are gone.
+    assert "T-RB260OP" in new_disk
+    assert "T-RB260OAR" in new_disk
+    assert "T-RB260DAR1" in new_disk, (
+        "done AR under open parent should ride forward (#260 follow-up)"
+    )
+    assert "T-RB260DTOP" not in new_disk
+    assert "T-RB260DPAR" not in new_disk
+
+    # Archive: top-level done declarations preserved (Bug #2 fix); open
+    # top-level becomes a ref row only.
+    assert "#task T-RB260OP" in arch_disk
+    assert "T-RB260DAR1" not in arch_disk, (
+        "done AR child of open parent must NOT duplicate into archive"
+    )
+    assert "T-RB260DTOP" in arch_disk, (
+        "top-level done declaration was previously swallowed by the "
+        "indent-unit bug; archive must preserve it"
+    )
+    assert "T-RB260DPAR" in arch_disk
+    assert "T-RB260DAR2" in arch_disk, (
+        "child of canonical-done parent must travel with the parent into archive"
+    )

--- a/VegaNotes/backend/tests/test_markdown_ops.py
+++ b/VegaNotes/backend/tests/test_markdown_ops.py
@@ -688,3 +688,126 @@ def test_safe_write_skips_non_md(tmp_path):
     p = tmp_path / "x.txt"
     safe_write(p, "  preserved\n", notes_dir=tmp_path)
     assert p.read_text() == "  preserved\n"
+
+
+# ── #260: rollover bugs ──────────────────────────────────────────────────
+_ROLL_FIXTURE_260 = (
+    "# weekly ww30\n"
+    "@admin\n"
+    "\t!task #id T-OPENPAR Open parent\n"
+    "\t\t!AR #id T-OPENAR open ar #status todo\n"
+    "\t\t!AR #id T-DONEAR1 done ar under open parent #status done\n"
+    "\t\t!AR #id T-DONEAR2 also done ar under open parent #status done\n"
+    "\t!task #id T-DONETOP Done top-level no kids #status done\n"
+    "\t!task #id T-DONEPAR Done parent with done kids #status done\n"
+    "\t\t!AR #id T-DONEAR3 done ar #status done\n"
+    "\t!task #id T-DONEPAROPEN Literal-done parent with open kid #status done\n"
+    "\t\t!AR #id T-OPENAR2 still open #status in-progress\n"
+)
+
+
+def test_260_archive_preserves_top_level_done_after_open_parent():
+    """Bug #2: ``_replace_top_level_open_with_refs`` used the parser's
+    abstract ``t.indent`` (level units) as the skip-block pivot but
+    compared each line with ``_line_indent`` (column count), causing
+    every later top-level row to be swallowed once the first open task
+    fired. Top-level done declarations vanished from the archive — true
+    data loss. This is now fixed by storing the pivot in line-column
+    units."""
+    from app.markdown_ops import roll_to_next_week
+    _, _, _, _, archived_md, _ = roll_to_next_week(_ROLL_FIXTURE_260, "ww30.md")
+    # The previously-lost declarations must reappear in the archive.
+    assert "T-DONETOP" in archived_md, "T-DONETOP swallowed by indent-unit bug"
+    assert "T-DONEPAR" in archived_md, "T-DONEPAR swallowed by indent-unit bug"
+    assert "T-DONEAR3" in archived_md, (
+        "T-DONEAR3 (child of done parent) lost with its parent"
+    )
+    # Ref rows for the open top-levels stay as-is.
+    assert "#task T-OPENPAR" in archived_md
+    # T-DONEPAROPEN is rolled UP to in-progress (open child) → treated as
+    # open → archive carries a ref row, not the canonical declaration.
+    assert "#task T-DONEPAROPEN" in archived_md
+
+
+def test_260_archive_drops_indent_blocks_under_open_top_levels():
+    """Open top-levels become single-line ref rows in the archive — their
+    children/continuations should NOT also appear there."""
+    from app.markdown_ops import roll_to_next_week
+    _, _, _, _, archived_md, _ = roll_to_next_week(_ROLL_FIXTURE_260, "ww30.md")
+    # Children of T-OPENPAR (an open task) must NOT be in the archive.
+    assert "T-OPENAR" not in archived_md, "open AR child of open parent leaked"
+    assert "T-DONEAR1" not in archived_md, (
+        "done AR child of open parent leaked into archive — those move "
+        "forward with the parent, the archive only has the ref row"
+    )
+
+
+def test_260_next_week_keeps_done_ars_under_open_parent():
+    """Per user request (#260 follow-up): when the parent task is NOT
+    done (literal status open OR rolled-up-to-open via mixed children),
+    its done AR children move forward with it so the next week shows
+    the audit trail of completed sub-items against still-open work."""
+    from app.markdown_ops import roll_to_next_week
+    new_md, *_ = roll_to_next_week(_ROLL_FIXTURE_260, "ww30.md")
+    # Open parent + every AR underneath survives.
+    assert "T-OPENPAR" in new_md
+    assert "T-OPENAR" in new_md      # open AR
+    assert "T-DONEAR1" in new_md     # done AR — KEEP because parent open
+    assert "T-DONEAR2" in new_md     # done AR — KEEP because parent open
+    # Literal-done parent with open kid → rolled up to in-progress →
+    # parent and its open AR survive.
+    assert "T-DONEPAROPEN" in new_md
+    assert "T-OPENAR2" in new_md
+
+
+def test_260_next_week_drops_top_level_done_subtrees():
+    """A top-level subtree where every node is rolled-up done falls out
+    of the next-week file entirely — nothing left to track there."""
+    from app.markdown_ops import roll_to_next_week
+    new_md, *_ = roll_to_next_week(_ROLL_FIXTURE_260, "ww30.md")
+    assert "T-DONETOP" not in new_md, "top-level standalone-done leaked"
+    assert "T-DONEPAR " not in new_md, "rolled-up done parent leaked"
+    assert "T-DONEAR3" not in new_md, "child of rolled-up done parent leaked"
+
+
+def test_260_next_week_no_orphan_done_children_in_archive_either():
+    """Sanity: T-DONEAR1/2 belong in the active week (their parent is
+    still open) and NOT duplicated into the archive — the archive's ref
+    row for T-OPENPAR is the only trace there."""
+    from app.markdown_ops import roll_to_next_week
+    new_md, _, _, _, archived_md, _ = roll_to_next_week(_ROLL_FIXTURE_260, "ww30.md")
+    # New week has them.
+    assert new_md.count("T-DONEAR1") == 1
+    # Archive does not.
+    assert "T-DONEAR1" not in archived_md
+    assert "T-DONEAR2" not in archived_md
+
+
+def test_260_repro_from_issue_goes_green():
+    """End-to-end: the repro pasted in #260 must produce the documented
+    "after fix" content, verbatim modulo trailing whitespace."""
+    from app.markdown_ops import roll_to_next_week
+    new_md, _, _, _, archived_md, _ = roll_to_next_week(_ROLL_FIXTURE_260, "ww30.md")
+
+    expected_new = (
+        "# weekly ww31\n"
+        "@admin\n"
+        "\t!task #id T-OPENPAR Open parent\n"
+        "\t\t!AR #id T-OPENAR open ar #status todo\n"
+        "\t\t!AR #id T-DONEAR1 done ar under open parent #status done\n"
+        "\t\t!AR #id T-DONEAR2 also done ar under open parent #status done\n"
+        "\t!task #id T-DONEPAROPEN Literal-done parent with open kid #status done\n"
+        "\t\t!AR #id T-OPENAR2 still open #status in-progress\n"
+    )
+    assert new_md == expected_new
+
+    expected_archive = (
+        "# weekly ww30\n"
+        "@admin\n"
+        "\t#task T-OPENPAR Open parent\n"
+        "\t!task #id T-DONETOP Done top-level no kids #status done\n"
+        "\t!task #id T-DONEPAR Done parent with done kids #status done\n"
+        "\t\t!AR #id T-DONEAR3 done ar #status done\n"
+        "\t#task T-DONEPAROPEN Literal-done parent with open kid #status done\n"
+    )
+    assert archived_md == expected_archive


### PR DESCRIPTION
Fixes #260.

## Bug (data loss in archive)

`_replace_top_level_open_with_refs` stored the skip-pivot in the
parser's abstract indent units (`info['indent']`, e.g. `2` for a
single tab) but compared each line via `_line_indent` which counts
columns (tab = 4). After the first open top-level row was hit,
`4 > 2` was always true, so every subsequent top-level row was
swallowed by the skip walker and never written to the archive.

User-visible symptom: hitting **Next Week** on a weekly note silently
dropped any top-level done tasks (and their children) from the
archived file. The active week was unaffected.

## Fix

Store the pivot in the same column-count units the comparator uses:

```python
skip_indent = _line_indent(lines[line_no])
```

## Behavior NOT changed

Per follow-up clarification: done ARs riding under an *open* parent
continue to roll forward into the next week (parent rolls up to
`in-progress`, audit trail preserved). Top-level subtrees that are
fully done (rolled-up) drop from the new file as before. The
`strip_top_level_done_tasks` helper is unchanged.

## Tests

- 6 unit tests in `tests/test_markdown_ops.py` (`test_260_*`)
  covering archive preservation, indent-block handling under an open
  top-level, AR retention under open parents, and the verbatim
  expected output from the issue repro.
- 1 integration test in `tests/api/test_api.py` against
  `POST /api/notes/next-week`.

Full backend suite: 391 passed (4 known flakes deselected).