### PR TITLE
fix(veganotes): bump wwN only in H1 during rollover, preserve task/note body (#263)

### DIFF
--- a/VegaNotes/backend/app/markdown_ops.py
+++ b/VegaNotes/backend/app/markdown_ops.py
@@ -232,9 +232,11 @@ def roll_to_next_week(
       ``!task`` / ``!AR`` declarations are MOVED here verbatim (with their
       entire indent block: nested children, ``#note`` continuations,
       done children of an open parent).  Done top-level blocks are
-      dropped — their canonical declarations stay in the archive.  Prose
-      ``wwN[.x]`` references matching ``current_ww`` are bumped by +1
-      (but never inside ``#eta`` values).
+      dropped — their canonical declarations stay in the archive.  The
+      ``wwN`` token in the H1 heading is bumped by +1; task titles,
+      ``#note`` continuations, and every other body line are preserved
+      verbatim (the user reviews/edits them deliberately — same policy
+      as ``#eta``).  See #263.
     * ``archived_md`` — contents to write to the source file's archive
       location.  Open top-level declarations are replaced with a single
       ``- #task <ID> <title>`` (or ``- #AR …``) reference row, with their
@@ -265,7 +267,7 @@ def roll_to_next_week(
     #    fully-completed top-level subtree; keep any AR whose top-level
     #    parent is still open".
     new_pruned = strip_top_level_done_tasks(patched_source)
-    new_body = _bump_ww_outside_eta(new_pruned, cur, nxt)
+    new_body = _bump_ww_in_h1(new_pruned, cur, nxt)
     new_base = bump_ww(basename, cur, nxt)
     # 3. Archive: replace top-level OPEN declarations with ref rows,
     #    drop their indent blocks.  Top-level DONE blocks stay canonical.
@@ -284,27 +286,41 @@ def roll_to_next_week(
 
 
 _ETA_TOKEN_RE = re.compile(r"#eta\s+\S+", re.IGNORECASE)
+# Match an H1 line (starts with a single `#` followed by space + content).
+_H1_LINE_RE = re.compile(r"^#\s+\S")
 
 
-def _bump_ww_outside_eta(text: str, cur: int, nxt: int) -> str:
-    """Bump `wwN` → `wwN+1` everywhere except inside `#eta <value>` tokens."""
-    eta_spans: list[tuple[int, int]] = [m.span() for m in _ETA_TOKEN_RE.finditer(text)]
+def _bump_ww_in_h1(text: str, cur: int, nxt: int) -> str:
+    """Bump ``wwN`` → ``wwN+1`` (where ``N == cur``) **only inside the first
+    H1 heading line** (e.g. ``# FIT Val weekly ww25``).
 
-    def in_eta(pos: int) -> bool:
-        for a, b in eta_spans:
-            if a <= pos < b:
-                return True
-        return False
-
-    def _sub(m: re.Match) -> str:
-        if in_eta(m.start()):
-            return m.group(0)
-        if int(m.group(1)) != cur:
-            return m.group(0)
-        frac = m.group(2) or ""
-        return f"ww{nxt}{frac}"
-
-    return _WW_NUM_RE.sub(_sub, text)
+    All other content — task titles, ``#note`` continuations, ``#eta``
+    values, and prose anywhere else in the file — is preserved verbatim.
+    Rolling a week forward must not silently rewrite historical body
+    text the user wrote with the previous week number in mind (#263).
+    """
+    in_fence = False
+    out: list[str] = []
+    bumped = False
+    for raw in text.splitlines(keepends=True):
+        if _FENCE_RE.match(raw):
+            in_fence = not in_fence
+            out.append(raw)
+            continue
+        if bumped or in_fence:
+            out.append(raw)
+            continue
+        if _H1_LINE_RE.match(raw):
+            def _sub(m: re.Match) -> str:
+                if int(m.group(1)) != cur:
+                    return m.group(0)
+                frac = m.group(2) or ""
+                return f"ww{nxt}{frac}"
+            out.append(_WW_NUM_RE.sub(_sub, raw))
+            bumped = True
+        else:
+            out.append(raw)
+    return "".join(out)
 
 
 def generate_task_id(existing: set[str] | None = None) -> str:

--- a/VegaNotes/backend/tests/test_markdown_ops.py
+++ b/VegaNotes/backend/tests/test_markdown_ops.py
@@ -811,3 +811,48 @@ def test_260_repro_from_issue_goes_green():
         "\t#task T-DONEPAROPEN Literal-done parent with open kid #status done\n"
     )
     assert archived_md == expected_archive
+
+
+# ── #263: only the H1 heading bumps wwN; task/note body is preserved ──
+def test_263_h1_bumps_but_task_and_note_body_do_not():
+    """Rolling forward must rewrite only the H1 ``wwN`` token. Task
+    titles, ``#note`` continuations, and any other body prose stay
+    verbatim (same policy as ``#eta``)."""
+    from app.markdown_ops import roll_to_next_week
+    md = (
+        "# FIT Val weekly ww25\n"
+        "@nancy\n"
+        "\n"
+        "\t!task #id T-OPEN1 prep ww25 dashboard #status wip\n"
+        "\t\t#note shared with ww25 cohort, see ww24 thread\n"
+        "\t\t!AR #id T-AR1 follow up with ww25 attendees #status todo\n"
+        "\t!task #id T-OPEN2 ww25 retrospective notes #eta ww25.3\n"
+    )
+    new_md, new_base, *_ = roll_to_next_week(md, "FIT weekly ww25.md")
+
+    assert new_base == "FIT weekly ww26.md"
+    assert "# FIT Val weekly ww26" in new_md
+    assert "# FIT Val weekly ww25" not in new_md
+    assert "prep ww25 dashboard" in new_md
+    assert "prep ww26 dashboard" not in new_md
+    assert "shared with ww25 cohort, see ww24 thread" in new_md
+    assert "follow up with ww25 attendees" in new_md
+    assert "ww25 retrospective notes" in new_md
+    assert "#eta ww25.3" in new_md
+    assert "#eta ww26.3" not in new_md
+
+
+def test_263_only_first_h1_is_bumped():
+    """If a stray ``# wwN`` line appears later in the body, leave it
+    alone — only the first H1 (the document title) bumps."""
+    from app.markdown_ops import roll_to_next_week
+    md = (
+        "# FIT Val weekly ww25\n"
+        "@nancy\n"
+        "\n"
+        "\t!task #id T-OPEN1 keep going #status wip\n"
+        "\t\t#note historical context from # ww25 status memo\n"
+    )
+    new_md, *_ = roll_to_next_week(md, "FIT weekly ww25.md")
+    assert new_md.count("ww26") == 1
+    assert "historical context from # ww25 status memo" in new_md


### PR DESCRIPTION
Closes #263.

## Problem

`roll_to_next_week` called `_bump_ww_outside_eta` over the entire file body, rewriting every `wwN[.x]` token (except inside `#eta`). Task titles such as `prep ww25 dashboard` and `#note` continuations such as `shared with ww25 cohort` were silently rewritten to `ww26` after pressing **Next Week**.

Body prose is historical context written with a specific week in mind. Like `#eta`, it should be preserved verbatim — the user re-reads and re-edits it deliberately.

## Fix

- Replace `_bump_ww_outside_eta` with `_bump_ww_in_h1`, which bumps `wwN` only inside the first H1 heading line (outside fenced code blocks).
- Filename bump via `bump_ww(basename, ...)` is unchanged.
- Update `roll_to_next_week` docstring.

## Tests

- `test_263_h1_bumps_but_task_and_note_body_do_not` — asserts task titles, `#note` continuations, and `#eta` values all survive verbatim while the H1 + filename bump.
- `test_263_only_first_h1_is_bumped` — only the first H1 changes; an in-line `# wwN` later in a note is left alone.

Full backend suite: 399 passed (4 known flakes deselected).