### PR TITLE
feat(veganotes): P0 close-celebration confetti + replay button (#180 tier-1 slice)

### DIFF
--- a/VegaNotes/frontend/src/components/Card/ConfettiBurst.tsx
+++ b/VegaNotes/frontend/src/components/Card/ConfettiBurst.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from "react";
+import { motion } from "framer-motion";
+
+/**
+ * Lightweight DOM-particle confetti burst (#180 P0 close celebration).
+ *
+ * No external lib — renders ~28 colored squares from a single point,
+ * each with a random angle/distance/rotation/scale, then fades out.
+ * Total animation ~1.2s. Designed to overlay an absolutely-positioned
+ * parent (TaskCard). `pointer-events: none` so it never steals clicks.
+ *
+ * Remounts every time `burstKey` changes (caller bumps the key to
+ * replay). When `burstKey === 0` nothing is rendered, so the card has
+ * zero footprint until the first close.
+ */
+export interface ConfettiBurstProps {
+  burstKey: number;
+  /** Particle count. Default 28. */
+  count?: number;
+  /** Burst spread radius in px (max). Default 140. */
+  radius?: number;
+  /** Total visible duration in seconds. Default 1.2. */
+  durationS?: number;
+}
+
+const PALETTE = [
+  "#f43f5e", // rose-500
+  "#f97316", // orange-500
+  "#eab308", // yellow-500
+  "#10b981", // emerald-500
+  "#3b82f6", // blue-500
+  "#a855f7", // purple-500
+  "#ec4899", // pink-500
+];
+
+interface Particle {
+  dx: number;
+  dy: number;
+  rot: number;
+  color: string;
+  size: number;
+  delay: number;
+}
+
+function buildParticles(count: number, radius: number): Particle[] {
+  const out: Particle[] = [];
+  for (let i = 0; i < count; i++) {
+    const angle = Math.random() * Math.PI * 2;
+    const dist = radius * (0.4 + Math.random() * 0.6);
+    out.push({
+      dx: Math.cos(angle) * dist,
+      dy: Math.sin(angle) * dist - Math.random() * 20,
+      rot: (Math.random() - 0.5) * 720,
+      color: PALETTE[Math.floor(Math.random() * PALETTE.length)],
+      size: 5 + Math.random() * 6,
+      delay: Math.random() * 0.08,
+    });
+  }
+  return out;
+}
+
+export function ConfettiBurst({
+  burstKey,
+  count = 28,
+  radius = 140,
+  durationS = 1.2,
+}: ConfettiBurstProps) {
+  // Re-seed particles whenever the caller bumps burstKey so each replay
+  // looks different.
+  const particles = useMemo(() => buildParticles(count, radius), [burstKey, count, radius]);
+
+  if (burstKey === 0) return null;
+
+  return (
+    <div
+      key={burstKey}
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 overflow-visible"
+    >
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
+        {particles.map((p, i) => (
+          <motion.span
+            key={i}
+            initial={{ x: 0, y: 0, rotate: 0, opacity: 1, scale: 1 }}
+            animate={{
+              x: p.dx,
+              y: p.dy,
+              rotate: p.rot,
+              opacity: 0,
+              scale: 0.6,
+            }}
+            transition={{
+              duration: durationS,
+              delay: p.delay,
+              ease: "easeOut",
+            }}
+            style={{
+              position: "absolute",
+              width: p.size,
+              height: p.size,
+              background: p.color,
+              borderRadius: 2,
+              boxShadow: `0 0 4px ${p.color}AA`,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/VegaNotes/frontend/src/components/Card/TaskCard.tsx
+++ b/VegaNotes/frontend/src/components/Card/TaskCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api, type ChildTask, type Task } from "../../api/client";
@@ -6,6 +6,9 @@ import { formatIntelWw } from "@veganotes/parser";
 import { useFontScale, FONT_SCALE_MAP } from "../../store/fontScale";
 import { QuickChips } from "../Tasks/QuickChips";
 import { copyToClipboard } from "../../lib/clipboard";
+import { isGamifyEnabled, subscribeGamify } from "../../lib/gamify";
+import { shouldFireP0Burst, shouldShowReplayButton } from "../../lib/p0Burst";
+import { ConfettiBurst } from "./ConfettiBurst";
 
 interface Props { task: Task; onOpen?: (t: Task) => void; canWrite?: boolean; }
 
@@ -64,6 +67,24 @@ export function TaskCard({ task, onOpen, canWrite = true }: Props) {
   const { scale } = useFontScale();
   const fs = FONT_SCALE_MAP[scale];
 
+  // ── #180: P0 close-celebration burst ────────────────────────────────
+  const [gamifyOn, setGamifyOn] = useState<boolean>(() => isGamifyEnabled());
+  useEffect(() => subscribeGamify(setGamifyOn), []);
+  const [burstKey, setBurstKey] = useState(0);
+  const prevStatusRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = task.status;
+    if (shouldFireP0Burst(prev, task.status, prio, gamifyOn)) {
+      setBurstKey((k) => k + 1);
+    }
+  }, [task.status, prio, gamifyOn]);
+  const replayBurst = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setBurstKey((k) => k + 1);
+  };
+  const showReplay = shouldShowReplayButton(task.status, prio, gamifyOn);
+
   const cycleAr = useMutation({
     mutationFn: ({ id, status }: { id: number; status: string }) =>
       api.updateTask(id, { status }),
@@ -79,9 +100,21 @@ export function TaskCard({ task, onOpen, canWrite = true }: Props) {
   return (
     <motion.div layout
       onClick={() => onOpen?.(task)}
-      className={`card border-l-4 ${accent} cursor-pointer`}>
+      className={`card border-l-4 ${accent} cursor-pointer relative`}>
+      <ConfettiBurst burstKey={burstKey} />
       <div className="flex items-start justify-between gap-2">
         <div className={`font-medium ${fs.title}`}>{task.title}</div>
+        {showReplay && (
+          <button
+            type="button"
+            onClick={replayBurst}
+            title="Replay celebration 🎉"
+            aria-label="Replay P0 close celebration"
+            className="shrink-0 rounded-full border border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100 hover:border-rose-300 transition-colors px-1.5 py-0.5 text-[11px] leading-none"
+          >
+            🎉
+          </button>
+        )}
       </div>
       <div className="mt-2 flex flex-wrap gap-1">
         {task.task_uuid && <UuidChip uuid={task.task_uuid} />}

--- a/VegaNotes/frontend/src/lib/p0Burst.ts
+++ b/VegaNotes/frontend/src/lib/p0Burst.ts
@@ -1,0 +1,51 @@
+/**
+ * P0-task close-celebration trigger logic (#180 — tier-1 burst).
+ *
+ * Pure helper, no React imports, so it is trivially unit-testable.
+ * Used by `<TaskCard>` to decide whether a status transition should
+ * fire a confetti burst, and by the "Replay" button shown on already
+ * closed P0 cards.
+ */
+
+export type GamifyReader = () => boolean;
+
+/**
+ * Decide whether a status transition warrants a P0 celebration burst.
+ *
+ * Fires only when ALL of these are true:
+ *   - previous status was not `done` (initial mount with status==='done'
+ *     is treated as "no transition" by passing prevStatus = null/undefined)
+ *   - next status is exactly `done`
+ *   - `priority` is exactly `"P0"` (case-insensitive)
+ *   - gamification is enabled (`gamifyEnabled === true`)
+ */
+export function shouldFireP0Burst(
+  prevStatus: string | null | undefined,
+  nextStatus: string | null | undefined,
+  priority: string | null | undefined,
+  gamifyEnabled: boolean,
+): boolean {
+  if (!gamifyEnabled) return false;
+  if (prevStatus == null) return false;
+  if (prevStatus === "done") return false;
+  if (nextStatus !== "done") return false;
+  const prio = (priority ?? "").trim().toUpperCase();
+  return prio === "P0";
+}
+
+/**
+ * True iff the "🎉 Replay" button should be offered on a card —
+ * the task is currently done, has P0 priority, and gamification is on.
+ *
+ * Reopens (status flipping away from `done`) hide the button again.
+ */
+export function shouldShowReplayButton(
+  status: string | null | undefined,
+  priority: string | null | undefined,
+  gamifyEnabled: boolean,
+): boolean {
+  if (!gamifyEnabled) return false;
+  if (status !== "done") return false;
+  const prio = (priority ?? "").trim().toUpperCase();
+  return prio === "P0";
+}

--- a/VegaNotes/frontend/tests/p0Burst.test.ts
+++ b/VegaNotes/frontend/tests/p0Burst.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { shouldFireP0Burst, shouldShowReplayButton } from "../src/lib/p0Burst";
+
+describe("p0Burst — shouldFireP0Burst", () => {
+  it("fires on transition todo → done for a P0", () => {
+    expect(shouldFireP0Burst("todo", "done", "P0", true)).toBe(true);
+  });
+
+  it("fires on transition in-progress → done for a P0", () => {
+    expect(shouldFireP0Burst("in-progress", "done", "P0", true)).toBe(true);
+  });
+
+  it("fires on transition blocked → done for a P0", () => {
+    expect(shouldFireP0Burst("blocked", "done", "P0", true)).toBe(true);
+  });
+
+  it("does NOT fire when prev is already done (re-render with no change)", () => {
+    expect(shouldFireP0Burst("done", "done", "P0", true)).toBe(false);
+  });
+
+  it("does NOT fire on the FIRST mount when status was unknown", () => {
+    // null = "no previous render yet" — never celebrate on initial load
+    expect(shouldFireP0Burst(null, "done", "P0", true)).toBe(false);
+    expect(shouldFireP0Burst(undefined, "done", "P0", true)).toBe(false);
+  });
+
+  it("does NOT fire when next status is not done (status moving sideways)", () => {
+    expect(shouldFireP0Burst("todo", "in-progress", "P0", true)).toBe(false);
+    expect(shouldFireP0Burst("done", "in-progress", "P0", true)).toBe(false);
+  });
+
+  it("does NOT fire for non-P0 priorities", () => {
+    expect(shouldFireP0Burst("todo", "done", "P1", true)).toBe(false);
+    expect(shouldFireP0Burst("todo", "done", "P2", true)).toBe(false);
+    expect(shouldFireP0Burst("todo", "done", "", true)).toBe(false);
+    expect(shouldFireP0Burst("todo", "done", null, true)).toBe(false);
+  });
+
+  it("is case-insensitive on priority", () => {
+    expect(shouldFireP0Burst("todo", "done", "p0", true)).toBe(true);
+    expect(shouldFireP0Burst("todo", "done", " P0 ", true)).toBe(true);
+  });
+
+  it("does NOT fire when gamification is opted out", () => {
+    expect(shouldFireP0Burst("todo", "done", "P0", false)).toBe(false);
+  });
+});
+
+describe("p0Burst — shouldShowReplayButton", () => {
+  it("shows for done P0 with gamify on", () => {
+    expect(shouldShowReplayButton("done", "P0", true)).toBe(true);
+  });
+
+  it("hides on non-done statuses (so reopening removes the button)", () => {
+    expect(shouldShowReplayButton("todo", "P0", true)).toBe(false);
+    expect(shouldShowReplayButton("in-progress", "P0", true)).toBe(false);
+    expect(shouldShowReplayButton("blocked", "P0", true)).toBe(false);
+  });
+
+  it("hides for non-P0 priorities", () => {
+    expect(shouldShowReplayButton("done", "P1", true)).toBe(false);
+    expect(shouldShowReplayButton("done", "", true)).toBe(false);
+    expect(shouldShowReplayButton("done", null, true)).toBe(false);
+  });
+
+  it("hides when gamification is off", () => {
+    expect(shouldShowReplayButton("done", "P0", false)).toBe(false);
+  });
+
+  it("is case-insensitive on priority", () => {
+    expect(shouldShowReplayButton("done", "p0", true)).toBe(true);
+    expect(shouldShowReplayButton("done", " P0 ", true)).toBe(true);
+  });
+});


### PR DESCRIPTION
First slice of #180. Scope intentionally narrowed to the user-requested pieces:

1. **Confetti burst** when a P0 task transitions to `done`.
2. **Replay button (🎉)** on a P0 card while it is `done`, to replay the burst.

Behaviour rules:

- Fires only on the `prev !== 'done' → next === 'done'` transition. Initial mount with `status === 'done'` does **not** celebrate (no party every page load).
- Non-P0 priorities (P1/P2/P3/none) do not trigger anything — out of scope.
- Honours the existing `veganotes.gamify` opt-out (`lib/gamify.ts` + `subscribeGamify`): flipping gamify off mid-session immediately hides the replay button and suppresses future bursts.

Out of scope for this PR (still open in #180):
- P1 burst variant
- 5 behaviour-based badges (Streak saver, Comeback, Pinch hitter, ETA saver, Cleanup crew)
- Opt-in workspace leaderboard

## Files

- **NEW** `src/lib/p0Burst.ts` — pure helpers (`shouldFireP0Burst`, `shouldShowReplayButton`). Case-insensitive priority match, null/undefined safe.
- **NEW** `src/components/Card/ConfettiBurst.tsx` — 28 framer-motion particles, ~1.2 s, pointer-events: none overlay. **No new npm deps**.
- `src/components/Card/TaskCard.tsx` — `useRef` previous status + `useEffect` transition detector → `burstKey` state → `<ConfettiBurst>` overlay; replay button in card header.
- **NEW** `tests/p0Burst.test.ts` — 14 vitest cases covering the transition matrix, priority case-insensitivity, first-mount suppression, reopen→reclose, and gamify-off behaviour.

## Verification

- `npx vitest run` → **176 / 176 pass** (was 162 → +14 new).
- `npx tsc --noEmit` → clean.
- `npx vite build` → clean.

Refs #180.