### PR TITLE
fix(veganotes): skip _archive/ in reindex_all + watcher to avoid duplicate-UUID startup crash

### DIFF
--- a/VegaNotes/backend/app/indexer/__init__.py
+++ b/VegaNotes/backend/app/indexer/__init__.py
@@ -768,6 +768,7 @@ def reindex_all(session: Session) -> int:
     """
     n = 0
     present: set[str] = set()
+    archived_paths: set[str] = set()
     for path in sorted(settings.notes_dir.rglob("*.md")):
         # Skip the per-write backup tree — paths under any ``.trash`` segment
         # are not real notes.  ``rglob('*.md')`` already excludes ``.bak``
@@ -780,6 +781,17 @@ def reindex_all(session: Session) -> int:
         if rel.startswith(".trash/") or "/.trash/" in rel or "/." in "/" + rel:
             # Skip dotfile dirs (.trash, .git, .vscode, etc.)
             continue
+        # Skip rolled-forward weekly archives.  After ``roll_to_next_week``
+        # moves canonical Task rows by uuid to the new ww file, the archived
+        # markdown still carries a body-prose copy of the same ``#task T-XXX``
+        # stamps — reindexing those copies would try to INSERT a Task with a
+        # ``task_uuid`` that already lives on the new note, hitting UNIQUE.
+        # The archived ``Note`` row is preserved (orphan sweep skips it
+        # below) so the body-prose copy stays browsable via
+        # ``?include_archived=1``; we just don't re-derive its tasks.
+        if "/_archive/" in f"/{rel}/":
+            archived_paths.add(rel)
+            continue
         reindex_file(path, session)
         present.add(rel)
         n += 1
@@ -789,10 +801,16 @@ def reindex_all(session: Session) -> int:
     # mounts where inotify is unreliable) leaves orphan tasks haunting the
     # UI and search results forever.  remove_path() cascades through
     # _delete_task_children + notes_fts.  See issue #207.
+    #
+    # NOTE: ``present`` only contains files we actually indexed.  Files
+    # under ``_archive/`` are intentionally not indexed (see above) but
+    # MUST be kept in the DB so the archive remains queryable, so we
+    # union them in here before the sweep.
+    keep = present | archived_paths
     orphans = 0
     all_notes = session.exec(select(Note)).all()
     for note in all_notes:
-        if note.path not in present:
+        if note.path not in keep:
             remove_path(note.path, session)
             orphans += 1
     if orphans:
@@ -978,6 +996,16 @@ async def watch_loop() -> None:
                 try:
                     rel = str(path.relative_to(settings.notes_dir))
                 except ValueError:
+                    continue
+                # Mirror reindex_all's skip list so a stray write/touch to a
+                # rolled-forward weekly archive can't re-introduce the
+                # duplicate-UUID INSERT crash.
+                if (
+                    rel.startswith(".trash/")
+                    or "/.trash/" in rel
+                    or "/." in "/" + rel
+                    or "/_archive/" in f"/{rel}/"
+                ):
                     continue
                 if change == Change.deleted or not path.exists():
                     remove_path(rel, s)


### PR DESCRIPTION
## Symptom
\`dev-start.sh --restart\` fails the backend on startup with:

\`\`\`
sqlalchemy.exc.IntegrityError: (sqlite3.IntegrityError) UNIQUE constraint failed: task.task_uuid
[SQL: INSERT INTO task (...) VALUES (..., 'T-63C696', ...)]
ERROR: Application startup failed. Exiting.
\`\`\`

## Root cause
\`roll_to_next_week\` bulk-reassigns canonical \`Task\` rows (by uuid)
from the source weekly note to the new ww file, but leaves the
original markdown lines untouched in \`_archive/<basename>\`. On the
next \`reindex_all\` pass, \`_incremental_reindex\` for that archived
\`Note\` finds parsed tasks whose uuids no longer match any of its
own \`Task\` rows (they migrated to the live ww file), tries to
INSERT them under the archive's \`note_id\`, and trips the global
\`UNIQUE(task_uuid)\` constraint because the live ww file already
owns that uuid.

In practice: live \`ww27.md\` + \`_archive/ww16.md…ww26.md\` all
share \`T-63C696\` / \`T-800631\` in body-prose → first archive walked
crashes startup.

## Fix
Treat \`_archive/\` like \`.trash/\` in both index walkers:

* **\`reindex_all\`** — skip any path with a \`_archive\` segment so
  archived markdown is not re-parsed, but **union those paths into
  \`keep\`** so the orphan-sweep does not delete the archived \`Note\`
  rows. They stay browsable via \`?include_archived=1\`.
* **watcher loop in \`run_watcher\`** — mirror the same skip rules so
  a stray write/touch under \`_archive/\` cannot re-introduce the
  crash through the incremental path.

## Validation
- \`./scripts/dev-start.sh --restart\` boots cleanly; \`/api/health\`-style
  probe passes.
- \`pytest backend/tests/\` — **398 pass** (with the 4 pre-existing
  flake deselects unchanged).
- Archived notes still appear under \`/api/notes?include_archived=1\`.