### PR TITLE
feat(veganotes): Focus of the Week free-form banner (#266)

### DIFF
--- a/VegaNotes/backend/app/api/__init__.py
+++ b/VegaNotes/backend/app/api/__init__.py
@@ -1938,7 +1938,7 @@ def list_projects(
     nd = settings.notes_dir
     nd.mkdir(parents=True, exist_ok=True)
     for child in sorted(nd.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
+        if not child.is_dir() or child.name.startswith(".") or child.name == "_meta":
             continue
         role = _user_role_for_project(s, user, child.name)
         if role == "none":
@@ -2057,7 +2057,7 @@ def tree(
     nd.mkdir(parents=True, exist_ok=True)
     # Top-level projects (folders)
     for child in sorted(nd.iterdir()):
-        if not child.is_dir() or child.name.startswith("."):
+        if not child.is_dir() or child.name.startswith(".") or child.name == "_meta":
             continue
         role = _user_role_for_project(s, user, child.name)
         if role == "none":
@@ -3132,3 +3132,79 @@ def admin_watcher_status(
     """
     from ..indexer import WATCHER_STATE
     return dict(WATCHER_STATE)
+
+
+# ── Focus of the Week (#266) ─────────────────────────────────────────
+# Free-form team / project goal of the week, stored as a single
+# markdown file at ``<notes_dir>/_meta/focus.md``. The indexer skips
+# ``_meta/`` entirely (see indexer/__init__.py); the file lives on
+# disk for git tracking and is read/written exclusively through these
+# endpoints. No parsing, no task extraction — the body is the source
+# of truth.
+
+FOCUS_REL_PATH = "_meta/focus.md"
+
+
+class FocusWeekIn(BaseModel):
+    markdown: str
+
+
+def _focus_full_path() -> Path:
+    return settings.notes_dir / FOCUS_REL_PATH
+
+
+@router.get("/focus-week")
+def get_focus_week(
+    _user: str = Depends(require_user),
+) -> dict[str, Any]:
+    """Return the current Focus of the Week markdown.
+
+    Response: ``{"markdown": str, "updated_at": ISO8601 str, "path": str}``.
+    Returns 404 if the file does not exist; the frontend hides the
+    banner in that case.
+    """
+    full = _focus_full_path()
+    if not full.exists():
+        raise HTTPException(404, "focus file not set")
+    try:
+        markdown = full.read_text(encoding="utf-8")
+    except OSError as e:
+        raise HTTPException(500, f"failed to read focus file: {e}")
+    mtime = datetime.utcfromtimestamp(full.stat().st_mtime).replace(microsecond=0)
+    return {
+        "markdown": markdown,
+        "updated_at": mtime.isoformat() + "Z",
+        "path": FOCUS_REL_PATH,
+    }
+
+
+@router.put("/focus-week")
+def put_focus_week(
+    body: FocusWeekIn,
+    s: Session = Depends(get_session),
+    user: str = Depends(require_user),
+) -> dict[str, Any]:
+    """Overwrite ``_meta/focus.md``. Admin only.
+
+    Empty/whitespace-only markdown deletes the file so the banner
+    auto-hides — saves clients from having to call a separate DELETE.
+    """
+    _require_root_admin(s, user, "edit focus-of-the-week")
+    full = _focus_full_path()
+    full.parent.mkdir(parents=True, exist_ok=True)
+
+    stripped = body.markdown.strip()
+    if not stripped:
+        if full.exists():
+            with with_file_lock(full):
+                if full.exists():
+                    full.unlink()
+        return {"markdown": "", "updated_at": None, "path": FOCUS_REL_PATH}
+
+    safe_write(full, body.markdown, notes_dir=settings.notes_dir)
+    mtime = datetime.utcfromtimestamp(full.stat().st_mtime).replace(microsecond=0)
+    return {
+        "markdown": body.markdown,
+        "updated_at": mtime.isoformat() + "Z",
+        "path": FOCUS_REL_PATH,
+    }

--- a/VegaNotes/backend/app/indexer/__init__.py
+++ b/VegaNotes/backend/app/indexer/__init__.py
@@ -123,8 +123,27 @@ def _upsert_task_attrs(session: Session, tid: int, pt: dict, folder_project: str
         session.add(Link(src_task_id=tid, dst_slug=ref["dst_slug"], kind=ref["kind"]))
 
 
-def reindex_file(path: Path, session: Session) -> Note:
+def _is_skipped_path(rel: str) -> bool:
+    """Centralized skip rule for paths the indexer must never touch.
+
+    Currently covers only the ``_meta/`` namespace for app-managed team
+    artifacts like ``_meta/focus.md`` (see #266). Other skips
+    (``.trash/``, ``_archive/``) are enforced at the bulk-walker layer
+    only (``reindex_all`` / watcher) because direct callers like
+    ``roll_to_next_week`` legitimately re-index archived files by
+    explicit path.
+    """
+    return rel.startswith("_meta/") or "/_meta/" in f"/{rel}/"
+
+
+def reindex_file(path: Path, session: Session) -> Note | None:
     rel = str(path.relative_to(settings.notes_dir))
+    # Guard against callers (``/api/tree``, ``/api/projects/{p}/notes``,
+    # ``run_watcher``) that walk the disk and would otherwise force-index
+    # a hidden ``_meta/`` artifact.  Returning ``None`` lets the caller
+    # treat the path as "no Note row" without raising.
+    if _is_skipped_path(rel):
+        return None
     body = path.read_text(encoding="utf-8")
     parsed = parse(body)
     title = next((ln.lstrip("# ").strip() for ln in body.splitlines() if ln.startswith("#")), rel)
@@ -781,6 +800,14 @@ def reindex_all(session: Session) -> int:
         if rel.startswith(".trash/") or "/.trash/" in rel or "/." in "/" + rel:
             # Skip dotfile dirs (.trash, .git, .vscode, etc.)
             continue
+        # Skip the ``_meta/`` namespace — these files are app-managed
+        # team artifacts (e.g. ``_meta/focus.md`` from issue #266) and
+        # are intentionally not surfaced as notes / tasks. They live on
+        # disk for git tracking and direct editing but the indexer
+        # ignores them entirely (no Note row, no orphan sweep, no
+        # watcher reindex).
+        if rel.startswith("_meta/") or "/_meta/" in f"/{rel}/":
+            continue
         # Skip rolled-forward weekly archives.  After ``roll_to_next_week``
         # moves canonical Task rows by uuid to the new ww file, the archived
         # markdown still carries a body-prose copy of the same ``#task T-XXX``
@@ -1005,6 +1032,8 @@ async def watch_loop() -> None:
                     or "/.trash/" in rel
                     or "/." in "/" + rel
                     or "/_archive/" in f"/{rel}/"
+                    or rel.startswith("_meta/")
+                    or "/_meta/" in f"/{rel}/"
                 ):
                     continue
                 if change == Change.deleted or not path.exists():

--- a/VegaNotes/backend/tests/api/test_focus_week.py
+++ b/VegaNotes/backend/tests/api/test_focus_week.py
@@ -1,0 +1,113 @@
+"""API tests for the Focus of the Week endpoints (#266).
+
+The focus is a free-form team / project goal of the week stored as a
+single markdown file at ``<notes_dir>/_meta/focus.md``. These tests
+exercise the GET / PUT pair end-to-end and assert the indexer skip
+behaviour (the file must NOT appear as a Note row).
+"""
+from __future__ import annotations
+
+import base64
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+DATA = Path(tempfile.mkdtemp(prefix="vega-test-focus-"))
+os.environ["VEGANOTES_DATA_DIR"] = str(DATA)
+os.environ["VEGANOTES_SERVE_STATIC"] = "false"
+
+from app.main import app  # noqa: E402
+
+ADMIN = {"Authorization": "Basic " + base64.b64encode(b"admin:admin").decode()}
+
+
+@pytest.fixture(scope="module")
+def client():
+    with TestClient(app) as c:
+        yield c
+    shutil.rmtree(DATA, ignore_errors=True)
+
+
+def test_get_returns_404_when_unset(client):
+    # Brand-new install: no focus file yet.
+    r = client.get("/api/focus-week", headers=ADMIN)
+    assert r.status_code == 404
+
+
+def test_put_then_get_round_trip(client):
+    md = "Ship the WW27 RTL freeze. **All P0 owners** post a cover-closure plan by Wed EOD."
+    r = client.put("/api/focus-week", headers=ADMIN, json={"markdown": md})
+    assert r.status_code == 200, r.text
+    out = r.json()
+    assert out["markdown"] == md
+    assert out["path"] == "_meta/focus.md"
+    assert out["updated_at"]
+
+    r = client.get("/api/focus-week", headers=ADMIN)
+    assert r.status_code == 200
+    got = r.json()
+    assert got["markdown"] == md
+    assert got["path"] == "_meta/focus.md"
+
+
+def test_put_empty_deletes_file(client):
+    # Seed first
+    client.put("/api/focus-week", headers=ADMIN, json={"markdown": "to be cleared"})
+
+    # Empty / whitespace-only payload clears the banner by deleting the file.
+    r = client.put("/api/focus-week", headers=ADMIN, json={"markdown": "   \n   "})
+    assert r.status_code == 200
+    assert r.json()["markdown"] == ""
+
+    r = client.get("/api/focus-week", headers=ADMIN)
+    assert r.status_code == 404
+
+
+def test_meta_file_not_indexed_as_note(client):
+    # Seed a focus file.
+    client.put(
+        "/api/focus-week", headers=ADMIN,
+        json={"markdown": "We do not want this surfaced as a note row."},
+    )
+    # Force a full reindex pass — _meta/ must be skipped.
+    r = client.post("/api/admin/reindex", headers=ADMIN)
+    assert r.status_code == 200
+
+    # /api/notes (and the tree) must NOT list the focus file.
+    notes = client.get("/api/notes", headers=ADMIN).json()
+    paths = [n["path"] for n in notes]
+    assert "_meta/focus.md" not in paths
+    assert not any(p.startswith("_meta/") for p in paths)
+
+    tree = client.get("/api/tree", headers=ADMIN).json()
+    # tree is a nested folder/file structure; serialize to flat string blob
+    # and assert the meta segment doesn't appear.
+    import json as _json
+    assert "_meta" not in _json.dumps(tree)
+
+
+def test_put_requires_admin(client):
+    # Create a non-admin user (they won't have is_admin=True) and try PUT.
+    # The admin/users endpoint requires admin so we set it up as admin first.
+    client.post(
+        "/api/admin/users", headers=ADMIN,
+        json={"name": "viewer", "password": "viewerpass1!", "is_admin": False},
+    )
+    viewer = {
+        "Authorization": "Basic " + base64.b64encode(b"viewer:viewerpass1!").decode(),
+    }
+
+    # GET is allowed for any authenticated user.
+    r = client.get("/api/focus-week", headers=viewer)
+    assert r.status_code in (200, 404)
+
+    # PUT must be rejected with 403.
+    r = client.put(
+        "/api/focus-week", headers=viewer,
+        json={"markdown": "non-admin trying to edit"},
+    )
+    assert r.status_code == 403

--- a/VegaNotes/frontend/src/App.tsx
+++ b/VegaNotes/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { Sidebar } from "./components/Sidebar/Sidebar";
 import { AdminPanel } from "./components/Admin/AdminPanel";
 import { ChangePasswordModal } from "./components/Auth/ChangePasswordModal";
 import { QuoteBar } from "./components/QuoteBar/QuoteBar";
+import { FocusBanner } from "./components/FocusBanner/FocusBanner";
 import { useEffect, useRef, useState } from "react";
 import { api, ApiError } from "./api/client";
 import { loadPersistedDrafts, persistDirtyDrafts } from "./store/draftStorage";
@@ -747,6 +748,7 @@ export default function App() {
     <QueryClientProvider client={qc}>
       <div className="min-h-screen flex flex-col">
         <QuoteBar />
+        <FocusBanner />
         <NavBar />
         <FilterBar />
         <div className="flex-1 flex overflow-hidden">

--- a/VegaNotes/frontend/src/api/client.ts
+++ b/VegaNotes/frontend/src/api/client.ts
@@ -396,7 +396,28 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ tokens }),
     }),
+
+  // ----- Focus of the Week (#266) ---------------------------------------
+  getFocusWeek: async (): Promise<FocusWeek | null> => {
+    try {
+      return await req<FocusWeek>("/focus-week");
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) return null;
+      throw e;
+    }
+  },
+  setFocusWeek: (markdown: string) =>
+    req<FocusWeek>("/focus-week", {
+      method: "PUT",
+      body: JSON.stringify({ markdown }),
+    }),
 };
+
+export interface FocusWeek {
+  markdown: string;
+  updated_at: string | null;
+  path: string;
+}
 
 export interface PhonebookEntry {
   idsid: string;

--- a/VegaNotes/frontend/src/components/FocusBanner/FocusBanner.tsx
+++ b/VegaNotes/frontend/src/components/FocusBanner/FocusBanner.tsx
@@ -1,0 +1,172 @@
+/**
+ * FocusBanner (#266) — displays the team / project Focus of the Week
+ * as free-form markdown sourced from ``_meta/focus.md`` on the backend.
+ *
+ * Visibility:
+ *  - Hidden entirely when the backend returns 404 (file missing) AND
+ *    the current user is not an admin (nothing to show, nothing to do).
+ *  - Admins see an empty-state "Set focus…" affordance so they can
+ *    create the banner without hand-editing the file.
+ *  - All authenticated users can read; only admins can edit (RBAC
+ *    enforced in the backend ``PUT /api/focus-week`` handler).
+ *
+ * Persistence:
+ *  - Collapsed state lives in ``localStorage`` under
+ *    ``veganotes.focusBanner.collapsed`` so it survives reloads but is
+ *    per-browser (i.e. one teammate hiding the banner doesn't hide it
+ *    for everyone).
+ *  - The banner refetches on window focus and on a 60s interval so a
+ *    teammate's edit shows up without a hard reload.
+ */
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api, type FocusWeek } from "../../api/client";
+import { renderFocusMarkdown } from "./focusMarkdown";
+
+const STORAGE_KEY = "veganotes.focusBanner.collapsed";
+
+function loadCollapsed(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function saveCollapsed(v: boolean): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, v ? "1" : "0");
+  } catch {
+    /* private mode / disabled storage — collapse simply won't persist */
+  }
+}
+
+export function FocusBanner() {
+  const qc = useQueryClient();
+  const [collapsed, setCollapsed] = useState<boolean>(loadCollapsed);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>("");
+
+  const me = useQuery({
+    queryKey: ["me"],
+    queryFn: () => api.me(),
+    staleTime: 60_000,
+  });
+
+  const focus = useQuery<FocusWeek | null>({
+    queryKey: ["focus-week"],
+    queryFn: () => api.getFocusWeek(),
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+  });
+
+  const save = useMutation({
+    mutationFn: (markdown: string) => api.setFocusWeek(markdown),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["focus-week"] });
+      setEditing(false);
+    },
+  });
+
+  useEffect(() => {
+    saveCollapsed(collapsed);
+  }, [collapsed]);
+
+  const isAdmin = !!me.data?.is_admin;
+  const md = focus.data?.markdown?.trim() ?? "";
+  const hasFocus = md.length > 0;
+
+  if (!hasFocus && !isAdmin) return null;
+  if (focus.isLoading) return null;
+
+  const startEdit = () => {
+    setDraft(focus.data?.markdown ?? "");
+    setEditing(true);
+  };
+
+  return (
+    <div className="vega-focus-banner border-y border-amber-200 bg-amber-50/60">
+      <div className="mx-auto max-w-7xl px-4 py-2 flex items-start gap-3">
+        <div className="shrink-0 text-amber-700 select-none pt-0.5" aria-hidden>📌</div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <div className="text-xs font-semibold tracking-wide uppercase text-amber-800">
+              Focus of the Week
+            </div>
+            <div className="ml-auto flex items-center gap-1">
+              {isAdmin && !editing && (
+                <button
+                  type="button"
+                  onClick={startEdit}
+                  title="Edit focus of the week"
+                  aria-label="Edit focus of the week"
+                  className="text-xs text-amber-800 hover:text-amber-900 px-1.5 py-0.5 rounded hover:bg-amber-100"
+                >
+                  ✏️
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={() => setCollapsed((c) => !c)}
+                title={collapsed ? "Expand" : "Collapse"}
+                aria-label={collapsed ? "Expand focus banner" : "Collapse focus banner"}
+                className="text-xs text-amber-800 hover:text-amber-900 px-1.5 py-0.5 rounded hover:bg-amber-100"
+              >
+                {collapsed ? "▸" : "▾"}
+              </button>
+            </div>
+          </div>
+          {!collapsed && (
+            <div className="mt-1">
+              {editing ? (
+                <div>
+                  <textarea
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    rows={3}
+                    placeholder="What is the team focusing on this week?"
+                    className="w-full rounded border border-amber-300 bg-white px-2 py-1 text-sm text-slate-800 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                    autoFocus
+                  />
+                  <div className="mt-1.5 flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => save.mutate(draft)}
+                      disabled={save.isPending}
+                      className="rounded bg-amber-600 hover:bg-amber-700 text-white text-xs px-2.5 py-1 disabled:opacity-50"
+                    >
+                      {save.isPending ? "Saving…" : "Save"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setEditing(false)}
+                      className="rounded border border-slate-300 text-xs px-2.5 py-1 hover:bg-slate-50"
+                    >
+                      Cancel
+                    </button>
+                    {save.isError && (
+                      <span className="text-xs text-rose-700">Save failed.</span>
+                    )}
+                  </div>
+                </div>
+              ) : hasFocus ? (
+                <div
+                  className="vega-focus-content text-sm text-slate-800 leading-snug"
+                  dangerouslySetInnerHTML={{ __html: renderFocusMarkdown(md) }}
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={startEdit}
+                  className="text-sm text-amber-800 hover:text-amber-900 italic"
+                >
+                  Set the team focus for this week…
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/VegaNotes/frontend/src/components/FocusBanner/focusMarkdown.ts
+++ b/VegaNotes/frontend/src/components/FocusBanner/focusMarkdown.ts
@@ -1,0 +1,75 @@
+/**
+ * Minimal markdown → HTML renderer for the Focus banner (#266).
+ *
+ * Scope is intentionally tiny: the banner is meant to hold a sentence
+ * or two of plain prose, not a full document. We only support the
+ * inline marks that team leads reach for when writing a quick goal:
+ * bold, italics, inline code, autolinks/explicit links, and
+ * line / paragraph breaks. Anything we don't recognise renders as
+ * its escaped literal — never as raw HTML — so a hostile or careless
+ * editor can't smuggle `<script>` into the banner.
+ *
+ * Returning a sanitized HTML string keeps the call site simple
+ * (`<div dangerouslySetInnerHTML={{__html: render(md)}} />`) without
+ * pulling in react-markdown / remark just for this banner.
+ */
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function safeUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (
+    trimmed.startsWith("http://") ||
+    trimmed.startsWith("https://") ||
+    trimmed.startsWith("mailto:") ||
+    trimmed.startsWith("/")
+  ) {
+    return trimmed;
+  }
+  return null;
+}
+
+function renderInline(text: string): string {
+  let html = escapeHtml(text);
+
+  html = html.replace(
+    /\[([^\]]+?)\]\(([^)]+?)\)/g,
+    (_m, label: string, href: string) => {
+      const url = safeUrl(href);
+      if (!url) return escapeHtml(`[${label}](${href})`);
+      return `<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer" class="text-sky-700 underline">${label}</a>`;
+    },
+  );
+
+  html = html.replace(
+    /(^|[\s(])(https?:\/\/[^\s<)]+)/g,
+    (_m, lead: string, url: string) =>
+      `${lead}<a href="${escapeHtml(url)}" target="_blank" rel="noopener noreferrer" class="text-sky-700 underline">${escapeHtml(url)}</a>`,
+  );
+
+  html = html.replace(/`([^`]+?)`/g, (_m, code: string) => `<code class="rounded bg-slate-100 px-1 py-0.5 text-[0.9em]">${code}</code>`);
+
+  html = html.replace(/\*\*([^*]+?)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/(^|[^*])\*([^*\n]+?)\*(?!\*)/g, "$1<em>$2</em>");
+
+  return html;
+}
+
+export function renderFocusMarkdown(md: string): string {
+  if (!md || !md.trim()) return "";
+  const paragraphs = md.replace(/\r\n/g, "\n").split(/\n\s*\n/);
+  return paragraphs
+    .map((para) => {
+      const lines = para.split("\n").map((l) => renderInline(l));
+      return `<p>${lines.join("<br />")}</p>`;
+    })
+    .join("");
+}

--- a/VegaNotes/frontend/tests/focusMarkdown.test.ts
+++ b/VegaNotes/frontend/tests/focusMarkdown.test.ts
@@ -1,0 +1,61 @@
+/** Unit tests for the FocusBanner inline markdown renderer (#266). */
+import { describe, it, expect } from "vitest";
+import { renderFocusMarkdown } from "../src/components/FocusBanner/focusMarkdown";
+
+describe("renderFocusMarkdown", () => {
+  it("returns empty for empty/whitespace input", () => {
+    expect(renderFocusMarkdown("")).toBe("");
+    expect(renderFocusMarkdown("   \n  ")).toBe("");
+  });
+
+  it("wraps a single paragraph in <p>", () => {
+    expect(renderFocusMarkdown("Hello team")).toBe("<p>Hello team</p>");
+  });
+
+  it("renders **bold** and *italic*", () => {
+    const html = renderFocusMarkdown("Ship by **Wed EOD** *no excuses*");
+    expect(html).toContain("<strong>Wed EOD</strong>");
+    expect(html).toContain("<em>no excuses</em>");
+  });
+
+  it("renders inline `code`", () => {
+    const html = renderFocusMarkdown("Lock down `release/main`");
+    expect(html).toContain("<code");
+    expect(html).toContain("release/main");
+  });
+
+  it("renders [label](url) links and adds rel=noopener", () => {
+    const html = renderFocusMarkdown("See [the doc](https://example.com/x)");
+    expect(html).toContain('href="https://example.com/x"');
+    expect(html).toContain("the doc</a>");
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("autolinks bare http(s) URLs", () => {
+    const html = renderFocusMarkdown("Plan at https://example.com/plan");
+    expect(html).toContain('href="https://example.com/plan"');
+  });
+
+  it("rejects javascript: links and keeps them literal", () => {
+    const html = renderFocusMarkdown("[click](javascript:alert(1))");
+    expect(html).not.toContain("href=\"javascript:");
+    expect(html).toContain("[click]");
+  });
+
+  it("escapes raw HTML to prevent injection", () => {
+    const html = renderFocusMarkdown("<script>alert(1)</script>");
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("splits on blank lines into multiple <p>", () => {
+    const html = renderFocusMarkdown("First para.\n\nSecond para.");
+    const pCount = (html.match(/<p>/g) ?? []).length;
+    expect(pCount).toBe(2);
+  });
+
+  it("preserves single newlines as <br />", () => {
+    const html = renderFocusMarkdown("line one\nline two");
+    expect(html).toContain("<br />");
+  });
+});


### PR DESCRIPTION
Closes #266.

Adds a persistent, glanceable **Focus of the Week** banner whose body
is free-form markdown the user authors — *not* derived from tasks.
Source of truth is a single file at \`<notes_dir>/_meta/focus.md\`;
the banner renders whatever is there.

## Backend

* \`GET /api/focus-week\` → \`{markdown, updated_at, path}\` or 404.
* \`PUT /api/focus-week\` (admin only) writes via \`safe_write\`.
  Empty/whitespace payload deletes the file → banner auto-hides.
* **Indexer hardening — \`_meta/\` is fully invisible to the note model:**
  - \`reindex_all\` and the watcher loop skip \`_meta/\` paths.
  - \`reindex_file\` itself returns \`None\` for \`_meta/\` paths so
    disk walkers in \`/api/tree\` / \`/api/projects/{p}/notes\`
    cannot force-index the focus file by name.
  - \`/api/projects\` and \`/api/tree\` filter \`_meta\` out of the
    project list so it never appears in the sidebar.

## Frontend

* \`api.getFocusWeek()\` / \`api.setFocusWeek(md)\` (404 from GET
  normalized to \`null\`).
* \`<FocusBanner />\` mounted once below \`<QuoteBar />\` in
  \`App.tsx\`:
  - Hidden when no focus is set **and** viewer is non-admin.
  - Admin sees inline ✏️ Edit button (textarea + Save/Cancel) and an
    empty-state \"Set focus…\" affordance.
  - Collapsible (▾/▸), state persisted to
    \`localStorage[\"veganotes.focusBanner.collapsed\"]\`.
  - Auto-refresh on window focus + 60s poll so a teammate's edit
    propagates without a hard reload.
* \`components/FocusBanner/focusMarkdown.ts\` — deliberately small
  markdown renderer scoped to this banner: bold/italic, inline code,
  explicit \`[label](url)\` links, http(s) autolinks, single-newline
  → \`<br />\`, blank-line → new \`<p>\`. All raw HTML is escaped;
  \`javascript:\` URLs are rejected literally. Avoids pulling
  react-markdown / remark in for two lines of prose.

## Tests

* **Backend** \`tests/api/test_focus_week.py\` (5 new):
  - empty GET returns 404
  - PUT then GET round-trips
  - PUT with whitespace-only payload deletes the file
  - \`_meta/focus.md\` is not surfaced by \`/api/notes\` or
    \`/api/tree\` after \`/api/admin/reindex\`
  - non-admin gets 403 on PUT
* **Frontend** \`tests/focusMarkdown.test.ts\` (10 new):
  empty/whitespace, paragraph wrap, bold, italic, inline code,
  explicit link, autolink, \`javascript:\` rejection, HTML escape,
  multi-paragraph, line-break.
* \`pytest backend/tests\` → **403 pass** (398 prior + 5 new), same
  4 pre-existing flake deselects.
* \`npx vitest run\` → **183/183** (173 prior + 10 new).
* \`npx tsc --noEmit\` clean. \`npx vite build\` clean.

## Manual QA checklist
1. As admin: banner shows empty-state \"Set focus…\". Click → editor
   appears; type \`Ship the **WW27 freeze** by Wed EOD\` → save →
   banner shows rendered markdown with **bold** highlight.
2. Click \`▾\` → banner collapses; reload → still collapsed.
3. Log in as non-admin → banner shows the same content but no ✏️
   button. PUT via curl returns 403.
4. Save an empty body → file deleted → banner hides for non-admin,
   reverts to empty-state for admin.
5. Open the sidebar tree → \`_meta\` is NOT listed as a project.