### PR TITLE
fix(veganotes): clamp long task titles in card + row views (#273)

### DIFF
--- a/VegaNotes/frontend/src/components/Card/TaskCard.tsx
+++ b/VegaNotes/frontend/src/components/Card/TaskCard.tsx
@@ -9,6 +9,7 @@ import { copyToClipboard } from "../../lib/clipboard";
 import { isGamifyEnabled, subscribeGamify } from "../../lib/gamify";
 import { shouldShowReplayButton } from "../../lib/p0Burst";
 import { triggerCelebration } from "../../lib/celebration";
+import { TitleWithBreakHints } from "../../lib/titleWrap";
 
 interface Props { task: Task; onOpen?: (t: Task) => void; canWrite?: boolean; }
 
@@ -105,7 +106,12 @@ export function TaskCard({ task, onOpen, canWrite = true }: Props) {
       onClick={() => onOpen?.(task)}
       className={`card border-l-4 ${accent} cursor-pointer relative`}>
       <div className="flex items-start justify-between gap-2">
-        <div className={`font-medium ${fs.title}`}>{task.title}</div>
+        <div
+          className={`font-medium ${fs.title} line-clamp-2 [overflow-wrap:anywhere] min-w-0 flex-1`}
+          title={task.title}
+        >
+          <TitleWithBreakHints text={task.title} />
+        </div>
         {showReplay && (
           <button
             type="button"
@@ -177,8 +183,16 @@ function ArRow({ ar, arClass, bubbleClass, onCycle }: {
       >
         {statusLabel}
       </button>
-      <span className={done ? "line-through text-slate-400 font-medium" : "text-slate-700 font-medium"}>
-        {ar.title}
+      <span
+        className={
+          (done
+            ? "line-through text-slate-400 font-medium"
+            : "text-slate-700 font-medium") +
+          " min-w-0 flex-1 line-clamp-2 [overflow-wrap:anywhere]"
+        }
+        title={ar.title}
+      >
+        <TitleWithBreakHints text={ar.title} />
       </span>
       {ar.eta && <span className={`chip chip-eta ${bubbleClass}`} title={ar.eta}>{etaLabel(ar.eta)}</span>}
     </li>

--- a/VegaNotes/frontend/src/components/Tasks/MyTasksView.tsx
+++ b/VegaNotes/frontend/src/components/Tasks/MyTasksView.tsx
@@ -24,6 +24,7 @@ import { loadDoneScope, saveDoneScope, type DoneScope } from "../../store/doneSc
 import { isGamifyEnabled, subscribeGamify } from "../../lib/gamify";
 import { shouldShowReplayButton } from "../../lib/p0Burst";
 import { triggerCelebration } from "../../lib/celebration";
+import { TitleWithBreakHints } from "../../lib/titleWrap";
 
 // ── selection helpers (issue #33) ─────────────────────────────────────────────
 
@@ -134,8 +135,16 @@ function ArRow({ ar, onCycle }: { ar: ChildTask; onCycle: () => void }) {
       >
         {statusLabel}
       </button>
-      <span className={done ? "line-through text-slate-400 font-medium" : "text-slate-700 font-medium"}>
-        {ar.title}
+      <span
+        className={
+          (done
+            ? "line-through text-slate-400 font-medium"
+            : "text-slate-700 font-medium") +
+          " min-w-0 truncate [overflow-wrap:anywhere]"
+        }
+        title={ar.title}
+      >
+        <TitleWithBreakHints text={ar.title} />
       </span>
       {ar.eta && <span className="chip chip-eta text-[10px]" title={ar.eta}>{etaLabel(ar.eta)}</span>}
     </li>
@@ -231,8 +240,11 @@ function TaskRow({
         {/* Title + project/feature chips + AR toggle */}
         <td className="py-2.5 pl-1 pr-2 min-w-[200px]">
           <div className="flex items-center gap-1.5">
-            <div className="font-medium text-slate-800 text-sm leading-snug group-hover:text-sky-800 transition-colors">
-              {task.title}
+            <div
+              className="font-medium text-slate-800 text-sm leading-snug group-hover:text-sky-800 transition-colors min-w-0 truncate max-w-[42ch] [overflow-wrap:anywhere]"
+              title={task.title}
+            >
+              <TitleWithBreakHints text={task.title} />
             </div>
             {showReplay && (
               <button

--- a/VegaNotes/frontend/src/components/Tasks/TaskEditPopover.tsx
+++ b/VegaNotes/frontend/src/components/Tasks/TaskEditPopover.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api, ApiError, type Task } from "../../api/client";
+import { TitleWithBreakHints } from "../../lib/titleWrap";
 
 const STATUSES = ["todo", "in-progress", "blocked", "done"];
 const PRIORITIES = ["", "P0", "P1", "P2", "P3"];
@@ -154,12 +155,14 @@ export function TaskEditPopover({ task, onClose }: Props) {
         className="bg-white rounded-lg shadow-xl w-[480px] max-w-[95vw] p-5 space-y-4"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-start justify-between">
-          <div>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
             <div className="text-xs text-slate-500 font-mono">
               T-{task.id} · {task.kind}
             </div>
-            <h3 className="font-semibold text-base mt-0.5">{task.title}</h3>
+            <h3 className="font-semibold text-base mt-0.5 [overflow-wrap:anywhere]">
+              <TitleWithBreakHints text={task.title} />
+            </h3>
           </div>
           <button
             onClick={onClose}

--- a/VegaNotes/frontend/src/lib/titleWrap.tsx
+++ b/VegaNotes/frontend/src/lib/titleWrap.tsx
@@ -1,0 +1,36 @@
+// Long task titles from RTL / verification workflows often have no
+// whitespace at all — e.g.
+//
+//   EID::1686927::IDQ_WR_EMRN_VALID_MISMATCH (4) -- ...
+//   fe::Assert::T_IDQ_RAT_FPV_Relamination_correctness_stimuli_1::gfc-a0
+//
+// These would either overflow the card horizontally or force the
+// browser to break at arbitrary character positions. Insert soft-break
+// hints after common delimiters (::, _, ., -, /) so the browser
+// prefers to wrap / truncate at semantically meaningful boundaries.
+//
+// Kept as a pure string-splitter for easy unit testing; the React
+// wrapper below interleaves <wbr /> elements between the segments.
+import React from "react";
+
+const DELIM_RE = /(::|__|_|\.|-|\/)/g;
+
+export function splitTitleForWrap(title: string): string[] {
+  if (!title) return [""];
+  const parts = title.split(DELIM_RE).filter((p) => p !== "");
+  return parts.length > 0 ? parts : [title];
+}
+
+export function TitleWithBreakHints({ text }: { text: string }): React.ReactElement {
+  const parts = splitTitleForWrap(text);
+  return (
+    <>
+      {parts.map((p, i) => (
+        <React.Fragment key={i}>
+          {p}
+          {i < parts.length - 1 && <wbr />}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/VegaNotes/frontend/tests/titleWrap.test.ts
+++ b/VegaNotes/frontend/tests/titleWrap.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { splitTitleForWrap } from "../src/lib/titleWrap";
+
+describe("splitTitleForWrap (#273)", () => {
+  it("returns single-element array for empty/plain titles", () => {
+    expect(splitTitleForWrap("")).toEqual([""]);
+    expect(splitTitleForWrap("Simple task")).toEqual(["Simple task"]);
+  });
+
+  it("splits on :: preserving delimiter", () => {
+    expect(splitTitleForWrap("fe::Assert::T_IDQ")).toEqual([
+      "fe", "::", "Assert", "::", "T", "_", "IDQ",
+    ]);
+  });
+
+  it("splits on _ and . and -", () => {
+    expect(splitTitleForWrap("foo_bar.baz-qux")).toEqual([
+      "foo", "_", "bar", ".", "baz", "-", "qux",
+    ]);
+  });
+
+  it("splits on /", () => {
+    expect(splitTitleForWrap("path/to/thing")).toEqual([
+      "path", "/", "to", "/", "thing",
+    ]);
+  });
+
+  it("handles real RTL regression bucket title", () => {
+    const t = "EID::1686927::IDQ_WR_EMRN_VALID_MISMATCH";
+    const parts = splitTitleForWrap(t);
+    // joining without delimiters must reconstruct original
+    expect(parts.join("")).toBe(t);
+    // has multiple wrap opportunities
+    expect(parts.length).toBeGreaterThan(4);
+  });
+
+  it("handles real FPV assertion title with no whitespace", () => {
+    const t = "fe::Assert::T_IDQ_RAT_FPV_Relamination_correctness_stimuli_1::msid_idq_fv_IDQ_RAT_intf_chk_inst_idq_rat_assume_uop_loop_genblk::gfc-a0";
+    const parts = splitTitleForWrap(t);
+    expect(parts.join("")).toBe(t);
+    // Every delimiter yields a wrap point → the browser can break at ::
+    // and _ boundaries instead of mid-word.
+    expect(parts.length).toBeGreaterThan(20);
+  });
+
+  it("round-trips arbitrary input (join === original)", () => {
+    const samples = [
+      "abc",
+      "abc::def",
+      "a_b_c",
+      "no-delims-just-hyphens",
+      "mix::of_types.and-things/here",
+      "",
+    ];
+    for (const s of samples) {
+      expect(splitTitleForWrap(s).join("")).toBe(s);
+    }
+  });
+
+  it("__ (double underscore) split treated as a single delimiter", () => {
+    // We list __ before _ in the regex alternation so it wins the match.
+    const parts = splitTitleForWrap("foo__bar");
+    expect(parts).toEqual(["foo", "__", "bar"]);
+  });
+});


### PR DESCRIPTION
Fixes #273

## Problem

Real long task titles from RTL / verification workflows spill outside the Kanban card and stretch MyTasks rows. Two representative examples from the issue:

```
EID::1686927::IDQ_WR_EMRN_VALID_MISMATCH (4) -- IDQ_WR_EMRN_VALID_MISMATCH - RTL=0, CTE=1 opcode=STD_DSZ64, lip:000000003BF01343 (Failed during TLM post processing)

fe::Assert::T_IDQ_RAT_FPV_Relamination_correctness_stimuli_1::msid_idq_fv_IDQ_RAT_intf_chk_inst_idq_rat_assume_uop_loop_genblk::gfc-a0
```

Both have ~40+ char unbroken tokens; the second has zero whitespace at all (~130 chars). Neither the Kanban card (`TaskCard.tsx`) nor the MyTasks row (`MyTasksView.tsx`) had truncation, tooltip, or wrap hints.

## Fix

Three-part solution applied at the two title render sites (and their AR sub-item titles):

1. **CSS clamp**
   - Kanban card: `line-clamp-2 [overflow-wrap:anywhere]` — max 2 lines with `…` ellipsis; `overflow-wrap:anywhere` uses min-content sizing so unbroken tokens can't force the card wider than its column.
   - MyTasks row: `truncate max-w-[42ch] [overflow-wrap:anywhere]` — single-line ellipsis capped at ~42 chars.

2. **Native tooltip** — `title={task.title}` on the wrapper exposes the full text on hover. Clicking the card / row still opens the drawer with the untruncated title.

3. **Semantic break hints** — new `TitleWithBreakHints` helper (in `src/lib/titleWrap.tsx`) inserts `<wbr />` after common identifier delimiters (`::`, `__`, `_`, `.`, `-`, `/`) so the browser prefers wrapping / truncating at semantic boundaries — e.g. `fe::Assert::T_IDQ_RAT_FPV_…` clamps at a `::` instead of mid-identifier.

The helper is a pure string splitter (`splitTitleForWrap`) so it can be unit-tested independently of any React runtime.

## Files

- `frontend/src/lib/titleWrap.tsx` — new helper + tiny React wrapper (~36 lines)
- `frontend/src/components/Card/TaskCard.tsx` — top-of-card title + AR sub-item title
- `frontend/src/components/Tasks/MyTasksView.tsx` — row title cell + AR sub-item title
- `frontend/tests/titleWrap.test.ts` — 8 new unit tests (split correctness, round-trip, the two real long-title examples)

## Tests

- Frontend: **191/191 pass** (was 183 + 8 new).
- `tsc --noEmit`: clean.
- `vite build`: clean.

## Backwards compatibility

- Short titles (the common case) render identically — the `<wbr />` markers are invisible and don't affect layout when the box has room.
- Full text is always preserved and reachable (hover tooltip + drawer/edit popover).
- No parser / backend changes.
